### PR TITLE
Fix accumulating memory leaks

### DIFF
--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -165,6 +165,9 @@ void deleteObject(NVDriver *drv, VAGenericID id) {
     } else if (drv->objRoot->id == id) {
         Object o = drv->objRoot;
         drv->objRoot = (Object) drv->objRoot->next;
+        if (o->obj != NULL) {
+            free(o->obj);
+        }
         free(o);
     } else {
         Object last = NULL;
@@ -176,6 +179,9 @@ void deleteObject(NVDriver *drv, VAGenericID id) {
 
         if (o != NULL) {
             last->next = o->next;
+            if (o->obj != NULL) {
+                free(o->obj);
+            }
             free(o);
         }
     }
@@ -726,6 +732,13 @@ VAStatus nvDestroyBuffer(
 
     Object obj = getObject(drv, buffer_id);
 
+    if (obj->obj != NULL) {
+        NVBuffer *buf = (NVBuffer*) obj->obj;
+        if (buf->ptr != NULL) {
+            free(buf->ptr);
+        }
+    }
+
     deleteObject(drv, buffer_id);
 
     return VA_STATUS_SUCCESS;
@@ -969,6 +982,13 @@ VAStatus nvDestroyImage(
 
     Object imageBufferObj = getObjectByPtr(drv, img->imageBuffer);
     if (imageBufferObj != NULL) {
+        NVBuffer *imageBuffer = (NVBuffer*) imageBufferObj->obj;
+        if (imageBuffer != NULL){
+            if (imageBuffer->ptr != NULL) {
+                free(imageBuffer->ptr);
+            }
+        }
+
         deleteObject(drv, imageBufferObj->id);
     }
 


### PR DESCRIPTION
I left my computer on overnight and woke up to find the Firefox RDD Process using 10GB of memory. I found the sources of these  memory leaks and fixed them. It seems like that was all of them.

Before:
![memleak](https://user-images.githubusercontent.com/8132027/148464413-4ef9701e-ac42-4105-b77b-eda2c956d0f7.png)

After:
![nomemleak](https://user-images.githubusercontent.com/8132027/148464857-6a818879-ce21-48fd-bd24-601085d3909b.png)

