### PR TITLE
cuda dynamic loader: Remove use of statics for function loading

### DIFF
--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -116,9 +116,9 @@ typedef struct _NVCodec
 
 void appendBuffer(AppendableBuffer *ab, const void *buf, uint64_t size);
 int pictureIdxFromSurfaceId(NVDriver *ctx, VASurfaceID surf);
-void checkCudaErrors(CUresult err, const char *file, const char *function, const int line);
+void checkCudaErrors(NVDriver *drv, CUresult err, const char *file, const char *function, const int line);
 void logger(const char *filename, const char *function, int line, const char *msg, ...);
-#define CHECK_CUDA_RESULT(err) checkCudaErrors(err, __FILE__, __func__, __LINE__)
+#define CHECK_CUDA_RESULT(err) checkCudaErrors(drv, err, __FILE__, __func__, __LINE__)
 #define cudaVideoCodec_NONE ((cudaVideoCodec) -1)
 #define LOG(...) logger(__FILE__, __func__, __LINE__, __VA_ARGS__);
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))


### PR DESCRIPTION
It looks like Firefox behaves in a way that uses multiple instances of
the driver at the same time which makes the statics usage unsafe. So
let's do the neccessary work to wire the NVDriver into all the places
it's needed.

Fixes #24