### PR TITLE
meson: Add a wrap file for ff-nvcodec-headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.o
 samples/*.mp4
+subprojects/*/

--- a/subprojects/ff-nvcodec-headers.wrap
+++ b/subprojects/ff-nvcodec-headers.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = nv-codec-headers-11.1.5.1
+source_url = https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.1.5.1/nv-codec-headers-11.1.5.1.tar.gz
+source_filename = nv-codec-headers-11.1.5.1.tar.gz
+source_hash = a28cdde3ac0e9e02c2dde7a1b4de5333b4ac6148a8332ca712da243a3361a0d9
+patch_filename = ff-nvcodec-headers_11.1.5.1-0_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/ff-nvcodec-headers_11.1.5.1-0/get_patch
+patch_hash = 5ecf67ad26f1e4a3f2a8e10b22b37130dea8c867058ba79271441fdfd4f524a6
+
+[provide]
+ffnvcodec = ffnvcodec_dep
+


### PR DESCRIPTION
This will automatically clone the repository and provide the ffnvcodec dependency if it is not found on the system. This should make it easier to build the repo. Here's what it looks like:

```console
nirbheek@mizui-iro-fedora ~/projects/repos/nvidia-vaapi-driver.git $ meson setup builddir
meson builddir
The Meson build system
Version: 0.59.4
Source dir: /home/nirbheek/projects/repos/nvidia-vaapi-driver.git
Build dir: /home/nirbheek/projects/repos/nvidia-vaapi-driver.git/builddir
Build type: native build
Project name: nvidia-vaapi-driver
Project version: 0.1
C compiler for the host machine: ccache cc (gcc 11.2.1 "cc (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)")
C linker for the host machine: cc ld.bfd 2.37-10
Host machine cpu family: x86_64
Host machine cpu: x86_64
Library m found: YES
Library dl found: YES
Library EGL found: YES
Found pkg-config: /usr/bin/pkg-config (1.8.0)
Run-time dependency gstreamer-codecparsers-1.0 found: YES 1.20.0
Did not find CMake 'cmake'
Found CMake: NO
Run-time dependency ffnvcodec found: NO (tried pkgconfig and cmake)
Looking for a fallback subproject for the dependency ffnvcodec
Downloading ff-nvcodec-headers source from https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.1.5.1/nv-codec-headers-11.1.5.1.tar.gz
Download size: 68516
Downloading: ..........
Downloading ff-nvcodec-headers patch from https://wrapdb.mesonbuild.com/v2/ff-nvcodec-headers_11.1.5.1-0/get_patch
Download size: 1302
Downloading: ..........

Executing subproject ff-nvcodec-headers 

ff-nvcodec-headers| Project name: ff-nvcodec-headers
ff-nvcodec-headers| Project version: 11.1.5.1
ff-nvcodec-headers| Build targets in project: 0
ff-nvcodec-headers| Subproject ff-nvcodec-headers finished.

Dependency ffnvcodec from subproject subprojects/nv-codec-headers-11.1.5.1 found: YES 11.1.5.1
Run-time dependency libva found: YES 1.13.0
Build targets in project: 1

nvidia-vaapi-driver 0.1

  Subprojects
    ff-nvcodec-headers: YES

Found ninja-1.10.2 at /usr/bin/ninja
nirbheek@mizui-iro-fedora ~/projects/repos/nvidia-vaapi-driver.git $ meson compile -C builddir/
ninja: Entering directory `builddir/'
[7/12] Compiling C object nvidia_drv_video.so.p/src_h264.c.o
../src/h264.c: In function ‘computeH264CudaCodec’:
../src/h264.c:116:5: warning: ‘VAProfileH264Baseline’ is deprecated [-Wdeprecated-declarations]
  116 |     if (profile == VAProfileH264Baseline || profile == VAProfileH264ConstrainedBaseline || profile == VAProfileH264Main || profile == VAProfileH264High) {
      |     ^~
In file included from /usr/include/va/va_backend.h:32,
                 from ../src/vabackend.h:5,
                 from ../src/h264.c:1:
/usr/include/va/va.h:501:5: note: declared here
  501 |     VAProfileH264Baseline va_deprecated_enum = 5,
      |     ^~~~~~~~~~~~~~~~~~~~~
../src/h264.c: At top level:
../src/h264.c:128:5: warning: ‘VAProfileH264Baseline’ is deprecated [-Wdeprecated-declarations]
  128 |     VAProfileH264Baseline,
      |     ^~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/va/va_backend.h:32,
                 from ../src/vabackend.h:5,
                 from ../src/h264.c:1:
/usr/include/va/va.h:501:5: note: declared here
  501 |     VAProfileH264Baseline va_deprecated_enum = 5,
      |     ^~~~~~~~~~~~~~~~~~~~~
[8/12] Compiling C object nvidia_drv_video.so.p/src_vabackend.c.o
../src/vabackend.c: In function ‘nvQueryConfigProfiles’:
../src/vabackend.c:307:9: warning: ‘VAProfileH264Baseline’ is deprecated [-Wdeprecated-declarations]
  307 |         profile_list[profiles++] = VAProfileH264Baseline;
      |         ^~~~~~~~~~~~
In file included from /usr/include/va/va_backend.h:32,
                 from ../src/vabackend.h:5,
                 from ../src/vabackend.c:3:
/usr/include/va/va.h:501:5: note: declared here
  501 |     VAProfileH264Baseline va_deprecated_enum = 5,
      |     ^~~~~~~~~~~~~~~~~~~~~
[12/12] Linking target nvidia_drv_video.so
nirbheek@mizui-iro-fedora ~/projects/repos/nvidia-vaapi-driver.git $ meson devenv -C builddir/
[nvidia-vaapi-driver] nirbheek@mizui-iro-fedora ~/projects/repos/nvidia-vaapi-driver.git/builddir $ vainfo
libva info: VA-API version 1.13.0
libva info: User environment variable requested driver 'nvidia'
libva info: Trying to open /home/nirbheek/projects/repos/nvidia-vaapi-driver.git/builddir/nvidia_drv_video.so
libva info: Found init function __vaDriverInit_1_0
[25148-25148] ../src/vabackend.c:1634       __vaDriverInit_1_0 Initialising NVIDIA VA-API Driver: 0x5586efe2fac0
[25148-25148] ../src/export-buf.c: 171          findCudaDisplay Found 3 EGL devices
[25148-25148] ../src/export-buf.c: 175          findCudaDisplay Got EGL_CUDA_DEVICE_NV value '0' from device 0
[25148-25148] ../src/export-buf.c: 135    checkModesetParameter Checking device file: /dev/dri/renderD128
[25148-25148] ../src/export-buf.c: 210             initExporter Got EGLDisplay from CUDA device
[25148-25148] ../src/export-buf.c: 240             initExporter Driver doesn't support 16-bit surfaces
[25148-25148] ../src/export-buf.c:  95                reconnect Reconnecting to stream
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.13 (libva 2.13.0)
vainfo: Driver version: VA-API NVDEC driver
vainfo: Supported profile and entrypoints
      VAProfileMPEG2Simple            :	VAEntrypointVLD
      VAProfileMPEG2Main              :	VAEntrypointVLD
      VAProfileVC1Simple              :	VAEntrypointVLD
      VAProfileVC1Main                :	VAEntrypointVLD
      VAProfileVC1Advanced            :	VAEntrypointVLD
      <unknown profile>               :	VAEntrypointVLD
      VAProfileH264Main               :	VAEntrypointVLD
      VAProfileH264High               :	VAEntrypointVLD
      VAProfileH264ConstrainedBaseline:	VAEntrypointVLD
      VAProfileHEVCMain               :	VAEntrypointVLD
      VAProfileVP9Profile0            :	VAEntrypointVLD
[25148-25148] ../src/vabackend.c:1618              nvTerminate Terminating 0x5586efe2fac0
[25148-25148] ../src/export-buf.c:  57          releaseExporter Releasing exporter, 0 outstanding frames
[25148-25148] ../src/export-buf.c:  74          releaseExporter Done releasing frames
```