### PR TITLE
Add alignment and remove static

### DIFF
--- a/src/av1.c
+++ b/src/av1.c
@@ -335,7 +335,7 @@ static const VAProfile av1SupportedProfiles[] =  {
     VAProfileAV1Profile1,
 };
 
-static const DECLARE_CODEC(av1Codec) = {
+const DECLARE_CODEC(av1Codec) = {
     .computeCudaCodec = computeAV1CudaCodec,
     .handlers = {
         [VAPictureParameterBufferType] = copyAV1PicParam,

--- a/src/h264.c
+++ b/src/h264.c
@@ -131,7 +131,7 @@ static const VAProfile h264SupportedProfiles[] = {
     VAProfileH264High,
 };
 
-static const DECLARE_CODEC(h264Codec) = {
+const DECLARE_CODEC(h264Codec) = {
     .computeCudaCodec = computeH264CudaCodec,
     .handlers = {
         [VAPictureParameterBufferType] = copyH264PicParam,

--- a/src/hevc.c
+++ b/src/hevc.c
@@ -307,7 +307,7 @@ static const VAProfile hevcSupportedProfiles[] = {
     // VAProfileHEVCMain12,
 };
 
-static const DECLARE_CODEC(hevcCodec) = {
+const DECLARE_CODEC(hevcCodec) = {
     .computeCudaCodec = computeHEVCCudaCodec,
     .handlers = {
         [VAPictureParameterBufferType] = copyHEVCPicParam,

--- a/src/jpeg.c
+++ b/src/jpeg.c
@@ -52,7 +52,7 @@ static const VAProfile jpegSupportedProfiles[] = {
     VAProfileJPEGBaseline,
 };
 
-static const DECLARE_CODEC(jpegCodec) = {
+const DECLARE_CODEC(jpegCodec) = {
     .computeCudaCodec = computeJPEGCudaCodec,
     .handlers = {
         [VAPictureParameterBufferType] = copyJPEGPicParam,

--- a/src/mpeg2.c
+++ b/src/mpeg2.c
@@ -146,7 +146,7 @@ static const VAProfile mpeg2SupportedProfiles[] = {
     VAProfileMPEG2Simple,
 };
 
-static const DECLARE_CODEC(mpeg2Codec) = {
+const DECLARE_CODEC(mpeg2Codec) = {
     .computeCudaCodec = computeMPEG2CudaCodec,
     .handlers = {
         [VAPictureParameterBufferType] = copyMPEG2PicParam,

--- a/src/mpeg4.c
+++ b/src/mpeg4.c
@@ -111,7 +111,7 @@ static const VAProfile mpeg4SupportProfiles[] = {
     VAProfileMPEG4AdvancedSimple,
 };
 
-static const DECLARE_CODEC(mpeg4Codec) = {
+const DECLARE_CODEC(mpeg4Codec) = {
     .computeCudaCodec = computeMPEG4CudaCodec,
     .handlers = {
         [VAPictureParameterBufferType] = copyMPEG4PicParam,

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -126,13 +126,15 @@ typedef cudaVideoCodec (*ComputeCudaCodec)(VAProfile);
 
 //padding/alignment is very important to this structure as it's placed in it's own section
 //in the executable.
-typedef struct _NVCodec
+struct _NVCodec
 {
     ComputeCudaCodec    computeCudaCodec;
     HandlerFunc         handlers[VABufferTypeMax];
     int                 supportedProfileCount;
     const VAProfile     *supportedProfiles;
-} NVCodec;
+} __attribute__((aligned));
+
+typedef struct _NVCodec NVCodec;
 
 void appendBuffer(AppendableBuffer *ab, const void *buf, uint64_t size);
 int pictureIdxFromSurfaceId(NVDriver *ctx, VASurfaceID surf);

--- a/src/vc1.c
+++ b/src/vc1.c
@@ -103,7 +103,7 @@ static const VAProfile vc1SupportedProfiles[] = {
     VAProfileVC1Advanced,
 };
 
-static const DECLARE_CODEC(vc1Codec) = {
+const DECLARE_CODEC(vc1Codec) = {
     .computeCudaCodec = computeVC1CudaCodec,
     .handlers = {
         [VAPictureParameterBufferType] = copyVC1PicParam,

--- a/src/vp8.c
+++ b/src/vp8.c
@@ -60,7 +60,7 @@ static const VAProfile vp8SupportedProfiles[] = {
     VAProfileVP8Version0_3,
 };
 
-static const DECLARE_CODEC(vp8Codec) = {
+const DECLARE_CODEC(vp8Codec) = {
     .computeCudaCodec = computeVP8CudaCodec,
     .handlers = {
         [VAPictureParameterBufferType] = copyVP8PicParam,

--- a/src/vp9.c
+++ b/src/vp9.c
@@ -157,7 +157,7 @@ static const VAProfile vp9SupportedProfiles[] = {
     VAProfileVP9Profile3,
 };
 
-static const DECLARE_CODEC(vp9Codec) = {
+const DECLARE_CODEC(vp9Codec) = {
     .computeCudaCodec = computeVP9CudaCodec,
     .handlers = {
         [VAPictureParameterBufferType] = copyVP9PicParam,


### PR DESCRIPTION
In #19 I forgot to add `__attribute__((aligned))` to `NVCodec`, and for some reason I marked the codec objects static, which looking back, I find a confusing choice.