### PR TITLE
vabackend: fix alignment of codecs

### DIFF
--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -132,7 +132,7 @@ struct _NVCodec
     HandlerFunc         handlers[VABufferTypeMax];
     int                 supportedProfileCount;
     const VAProfile     *supportedProfiles;
-} __attribute__((aligned));
+};
 
 typedef struct _NVCodec NVCodec;
 
@@ -147,7 +147,7 @@ void logger(const char *filename, const char *function, int line, const char *ms
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 #define PTROFF(base, bytes) ((void *)((unsigned char *)(base) + (bytes)))
 #define DECLARE_CODEC(name) \
-    __attribute__((section("nvd_codecs"), used)) \
+    __attribute__((used, section("nvd_codecs"), aligned(__alignof__(NVCodec)))) \
     NVCodec name
 
 #endif // VABACKEND_H


### PR DESCRIPTION
Making the `NVCodec` structs maximally aligned was an erroneous move because the gcc may increase the alignment which can lead to undesirable behaviour (e.g. #71).

In the aforementioned case the size of the struct was 496 bytes, which was properly aligned to the maximum alignment (`__BIGGEST_ALIGNMENT__`) on the platform (16 bytes - x86-64), but gcc chose to align the objects at a 32 byte boundary, which resulted in 16 bytes of padding between each element that was not accounted for at runtime.

Specifying the alignment on the object itself and not the type prevents gcc from increasing the alignment.

See: https://lore.kernel.org/lkml/20201103175711.10731-1-johan@kernel.org/

Fixes: 73ddb632c2f3fb ("vabackend: make NVCodec struct aligned")