### PR TITLE
vabackend: retain section from linker garbage collection

### DIFF
--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -171,7 +171,10 @@ void logger(const char *filename, const char *function, int line, const char *ms
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 #define PTROFF(base, bytes) ((void *)((unsigned char *)(base) + (bytes)))
 #define DECLARE_CODEC(name) \
-    __attribute__((used, section("nvd_codecs"), aligned(__alignof__(NVCodec)))) \
+    __attribute__((used)) \
+    __attribute__((retain)) \
+    __attribute__((section("nvd_codecs"))) \
+    __attribute__((aligned(__alignof__(NVCodec)))) \
     NVCodec name
 
 #endif // VABACKEND_H


### PR DESCRIPTION
The linker may remove sections that are actually used when "--gc-sections" and "-z start-stop-gc" is set. Add the `retain` attribute to prevent that.

See: https://lld.llvm.org/ELF/start-stop-gc.html
See: https://github.com/systemd/systemd/issues/21847
See: https://github.com/systemd/systemd/pull/21855