### PR TITLE
Add option to limit maximum instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ meson setup build
 meson install -C build
 ```
 
-# Debugging
+# Environment Variables
 
-The `NVD_LOG` environment variable can be used to control logging, `NVD_LOG=1` will log to stdout, and `NVD_LOG=<filename>` will append to the specified file (or stdout if the file can't be opened).
+| Variable | Purpose |
+|---|---|
+|`NVD_LOG`|This environment variable can be used to control logging, if it's set to `1` it will log to stdout. If it is set to anything else, it will use that as the filename to append to (or stdout if the file can't be opened).|
+|`NVD_MAX_INSTANCES`|This environment variable controls the maximum concurrent instances of the driver will be allowed per-process. This option is only really useful for older GPUs with not much VRAM, especially with Firefox on video heavy websites. |
 
 # Firefox
 

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -63,7 +63,7 @@ static void init() {
     }
 
     char *nvdMaxInstances = getenv("NVD_MAX_INSTANCES");
-    if (nvdGpu != NULL) {
+    if (nvdMaxInstances != NULL) {
         max_instances = atoi(nvdMaxInstances);
     }
 

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -27,6 +27,10 @@
 
 #include <time.h>
 
+pthread_mutex_t concurrency_mutex;
+static uint32_t instances;
+static uint32_t max_instances = 0;
+
 static CudaFunctions *cu;
 static CuvidFunctions *cv;
 
@@ -56,6 +60,11 @@ static void init() {
     char *nvdGpu = getenv("NVD_GPU");
     if (nvdGpu != NULL) {
         gpu = atoi(nvdGpu);
+    }
+
+    char *nvdMaxInstances = getenv("NVD_MAX_INSTANCES");
+    if (nvdGpu != NULL) {
+        max_instances = atoi(nvdMaxInstances);
     }
 
     //try to detect the Firefox sandbox and skip loading CUDA if detected
@@ -1752,6 +1761,11 @@ static VAStatus nvTerminate( VADriverContextP ctx )
 
     cu->cuCtxDestroy(drv->cudaContext);
 
+    pthread_mutex_lock(&concurrency_mutex);
+    instances--;
+    LOG("Now have %d (%d max) instances", instances, max_instances);
+    pthread_mutex_unlock(&concurrency_mutex);
+
     return VA_STATUS_SUCCESS;
 }
 
@@ -1759,6 +1773,16 @@ __attribute__((visibility("default")))
 VAStatus __vaDriverInit_1_0(VADriverContextP ctx)
 {
     LOG("Initialising NVIDIA VA-API Driver: %p %X", ctx, ctx->display_type);
+
+    pthread_mutex_lock(&concurrency_mutex);
+    LOG("Now have %d (%d max) instances", instances, max_instances);
+    if (max_instances > 0 && instances >= max_instances) {
+        pthread_mutex_unlock(&concurrency_mutex);
+        return VA_STATUS_ERROR_HW_BUSY;
+    }
+    instances++;
+    pthread_mutex_unlock(&concurrency_mutex);
+
 
     if (gpu == -1 && (ctx->display_type & VA_DISPLAY_MAJOR_MASK) != VA_DISPLAY_DRM) {
         LOG("Non-DRM display type detected, defaulting to GPU ID 0. Use NVD_GPU to pick a specific GPU.");


### PR DESCRIPTION
This PR adds the `NVD_MAX_INSTANCES` option. This option will prevent more than the specified amount of instances of the driver running within a single process. This option is mostly to prevent Firefox from created unbounded amount of instances and exhausting VRAM.

Fixes #80