### PR TITLE
meson: Make gst-codecparser optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,28 +16,33 @@ cc = meson.get_compiler('c')
 m_dep = cc.find_library('m')
 dl_dep = cc.find_library('dl', required : false)
 egl_dep = cc.find_library('EGL')
-gst_codecs_deps = dependency('gstreamer-codecparsers-1.0')
+gst_codecs_deps = dependency('gstreamer-codecparsers-1.0', required: false)
 ffnvcodec_deps = dependency('ffnvcodec', version: '>= 11.1.5.1')
 libva_deps = dependency('libva', version: '>= 1.8.0')
 thread_dep = dependency('threads')
 
+sources = [
+    'src/av1.c',
+    'src/export-buf.c',
+    'src/h264.c',
+    'src/hevc.c',
+    'src/jpeg.c',
+    'src/mpeg2.c',
+    'src/mpeg4.c',
+    'src/vabackend.c',
+    'src/vc1.c',
+    'src/vp8.c',
+    'src/list.c',
+]
+
+if gst_codecs_deps.found()
+    sources += ['src/vp9.c',]
+endif
+
 shared_library(
     'nvidia_drv_video',
     name_prefix: '',
-    sources: [
-        'src/av1.c',
-        'src/export-buf.c',
-        'src/h264.c',
-        'src/hevc.c',
-        'src/jpeg.c',
-        'src/mpeg2.c',
-        'src/mpeg4.c',
-        'src/vabackend.c',
-        'src/vc1.c',
-        'src/vp8.c',
-        'src/vp9.c',
-        'src/list.c',
-    ],
+    sources: sources,
     dependencies: [
         libva_deps,
         ffnvcodec_deps,


### PR DESCRIPTION
Disable vp8 and vp9 if not available.

I'm not sure how truly useful this is, but gstreamer has a huge pile of dependencies, and maybe one might not want to install all of them just to get access to the codecparser if vp8 and vp9 aren't essential for you.