### PR TITLE
vabackend: support 10/12 bit formats

### DIFF
--- a/src/hevc.c
+++ b/src/hevc.c
@@ -294,7 +294,7 @@ static cudaVideoCodec computeHEVCCudaCodec(VAProfile profile) {
     switch (profile) {
         case VAProfileHEVCMain:
         case VAProfileHEVCMain10:
-        //case VAProfileHEVCMain12: //need to wait for ffmpeg to support this via VA-API
+        case VAProfileHEVCMain12:
             return cudaVideoCodec_HEVC;
         default:
             return cudaVideoCodec_NONE;
@@ -304,7 +304,7 @@ static cudaVideoCodec computeHEVCCudaCodec(VAProfile profile) {
 static const VAProfile hevcSupportedProfiles[] = {
     VAProfileHEVCMain,
     VAProfileHEVCMain10,
-    // VAProfileHEVCMain12,
+    VAProfileHEVCMain12,
 };
 
 const DECLARE_CODEC(hevcCodec) = {

--- a/src/vp9.c
+++ b/src/vp9.c
@@ -33,8 +33,8 @@ static void copyVP9PicParam(NVContext *ctx, NVBuffer* buffer, CUVIDPICPARAMS *pi
     picParams->CodecSpecific.vp9.allow_high_precision_mv = buf->pic_fields.bits.allow_high_precision_mv;
     picParams->CodecSpecific.vp9.refreshEntropyProbs = buf->pic_fields.bits.refresh_frame_context;
 
-//    picParams->CodecSpecific.vp9.bitDepthMinus8Luma = buf->pic_fields.bits.;
-//    picParams->CodecSpecific.vp9.bitDepthMinus8Chroma = buf->pic_fields.bits.;
+    picParams->CodecSpecific.vp9.bitDepthMinus8Luma = buf->bit_depth - 8;
+    picParams->CodecSpecific.vp9.bitDepthMinus8Chroma = buf->bit_depth - 8;
 
     picParams->CodecSpecific.vp9.loopFilterLevel = buf->filter_level;
     picParams->CodecSpecific.vp9.loopFilterSharpness = buf->sharpness_level;


### PR DESCRIPTION
The latest nvidia 520 drivers include support for the required DRM
formats to allow exporting of 10/12 bit surfaces.

The driver currently has incomplete support and various bits and
pieces commented out.

This change is an initial attempt to implement the required support for
the relevant profiles.

Things are simple where the profile and bit depth have a 1:1
correspondence, but AV1Profile0 includes both 8 and 10 bit content,
while VP9Profile2 includes 10 and 12 bit.

In these cases, we have to have a way to learn from the caller what
format is desired. In the most straight-forward case, the call to
createConfig will specify which format the caller wants as an RtFormat,
but this is optional. They are allowed to specify nothing.

On the other hand, other callers can provide pre-allocated surfaces
when calling createContext, and we can look at the surface format to
work out what they want.

What if a caller didn't provide either hint? We'd end up having to
guess and just assume 8bit. In practice, we believe that all relevant
callers use one of the above patterns.

Fixes #34 