### PR TITLE
Support YUV444 on direct-backend

### DIFF
--- a/src/direct/direct-export-buf.c
+++ b/src/direct/direct-export-buf.c
@@ -124,18 +124,30 @@ BackingImage *direct_allocateBackingImage(NVDriver *drv, const NVSurface *surfac
     switch (surface->format)
     {
     case cudaVideoSurfaceFormat_P016:
-        if (surface->bitDepth == 10) {
+        switch (surface->bitDepth) {
+        case 10:
             backingImage->format = NV_FORMAT_P010;
-        } else {
+            break;
+        case 12:
             backingImage->format = NV_FORMAT_P012;
+            break;
+        default:
+            backingImage->format = NV_FORMAT_P016;
+            break;
         }
         break;
 
     case cudaVideoSurfaceFormat_YUV444_16Bit:
-        if (surface->bitDepth == 10) {
+        switch (surface->bitDepth) {
+        case 10:
             backingImage->format = NV_FORMAT_Q410;
-        } else {
+            break;
+        case 12:
             backingImage->format = NV_FORMAT_Q412;
+            break;
+        default:
+            backingImage->format = NV_FORMAT_Q416;
+            break;
         }
         break;
 

--- a/src/direct/direct-export-buf.c
+++ b/src/direct/direct-export-buf.c
@@ -67,6 +67,7 @@ bool direct_initExporter(NVDriver *drv) {
     //TODO this isn't really correct as we don't know if the driver version actually supports importing them
     //but we don't have an easy way to find out.
     drv->supports16BitSurface = true;
+    drv->supports444Surface = true;
     findGPUIndexFromFd(drv);
 
     return ret;
@@ -114,51 +115,68 @@ static bool import_to_cuda(NVDriver *drv, NVDriverImage *image, int bpc, int cha
 }
 
 BackingImage *direct_allocateBackingImage(NVDriver *drv, const NVSurface *surface) {
-    NVDriverImage driverImages[2] = { 0 };
-    int bpp = surface->format == cudaVideoSurfaceFormat_NV12 ? 8 : 16;
+    NVDriverImage driverImages[3] = { 0 };
+    const NVFormatInfo *fmtInfo;
+    const NVFormatPlane *p;
 
     BackingImage *backingImage = calloc(1, sizeof(BackingImage));
 
-    LOG("Allocating BackingImages: %p %dx%d", backingImage, surface->width, surface->height);
-    alloc_image(&drv->driverContext, surface->width, surface->height, 1, bpp, &driverImages[0]);
-    alloc_image(&drv->driverContext, surface->width>>1, surface->height>>1, 2, bpp, &driverImages[1]);
-
-    if (!import_to_cuda(drv, &driverImages[0], bpp, 1, &backingImage->cudaImages[0], &backingImage->arrays[0])) {
-        goto bail;
-    }
-    if (!import_to_cuda(drv, &driverImages[1], bpp, 2, &backingImage->cudaImages[1], &backingImage->arrays[1])) {
-        goto bail;
-    }
-
-    backingImage->fds[0] = driverImages[0].drmFd;
-    backingImage->fds[1] = driverImages[1].drmFd;
-
-    if (surface->format == cudaVideoSurfaceFormat_P016) {
+    switch (surface->format)
+    {
+    case cudaVideoSurfaceFormat_P016:
         if (surface->bitDepth == 10) {
-            backingImage->fourcc = DRM_FORMAT_P010;
+            backingImage->format = NV_FORMAT_P010;
         } else {
-            backingImage->fourcc = DRM_FORMAT_P012;
+            backingImage->format = NV_FORMAT_P012;
         }
-    } else {
-        backingImage->fourcc = DRM_FORMAT_NV12;
+        break;
+
+    case cudaVideoSurfaceFormat_YUV444_16Bit:
+        if (surface->bitDepth == 10) {
+            backingImage->format = NV_FORMAT_Q410;
+        } else {
+            backingImage->format = NV_FORMAT_Q412;
+        }
+        break;
+
+    case cudaVideoSurfaceFormat_YUV444:
+        backingImage->format = NV_FORMAT_444P;
+        break;
+    
+    default:
+        backingImage->format = NV_FORMAT_NV12;
+        break;
+    }
+
+    fmtInfo = &formatsInfo[backingImage->format];
+    p = fmtInfo->plane;
+
+    LOG("Allocating BackingImages: %p %dx%d", backingImage, surface->width, surface->height);
+    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+        alloc_image(&drv->driverContext, surface->width >> p[i].ss.x, surface->height >> p[i].ss.y,
+            p[i].channelCount, 8 * fmtInfo->bppc, p[i].fourcc, &driverImages[i]);
+    }
+
+    LOG("Importing images");
+    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+        if (!import_to_cuda(drv, &driverImages[i], 8 * fmtInfo->bppc, p[i].channelCount, &backingImage->cudaImages[i], &backingImage->arrays[i]))
+            goto bail;
     }
 
     backingImage->width = surface->width;
     backingImage->height = surface->height;
 
-    backingImage->strides[0] = driverImages[0].pitch;
-    backingImage->strides[1] = driverImages[1].pitch;
-
-    backingImage->mods[0] = driverImages[0].mods;
-    backingImage->mods[1] = driverImages[1].mods;
-
-    backingImage->size[0] = driverImages[0].memorySize;
-    backingImage->size[1] = driverImages[1].memorySize;
+    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+        backingImage->fds[i] = driverImages[i].drmFd;
+        backingImage->strides[i] = driverImages[i].pitch;
+        backingImage->mods[i] = driverImages[i].mods;
+        backingImage->size[i] = driverImages[i].memorySize;
+    }
 
     return backingImage;
 
 bail:
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < fmtInfo->numPlanes; i++) {
         if (driverImages[i].nvFd != 0) {
             close(driverImages[i].nvFd);
         }
@@ -174,6 +192,7 @@ bail:
 }
 
 static void destroyBackingImage(NVDriver *drv, BackingImage *img) {
+    const NVFormatInfo *fmtInfo = &formatsInfo[img->format];
     LOG("Destroying BackingImage: %p", img);
     if (img->surface != NULL) {
         img->surface->backingImage = NULL;
@@ -185,7 +204,7 @@ static void destroyBackingImage(NVDriver *drv, BackingImage *img) {
         }
     }
 
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < fmtInfo->numPlanes; i++) {
         if (img->arrays[i] != NULL) {
             CHECK_CUDA_RESULT(drv->cu->cuArrayDestroy(img->arrays[i]));
         }
@@ -224,28 +243,29 @@ void direct_destroyAllBackingImage(NVDriver *drv) {
 }
 
 static bool copyFrameToSurface(NVDriver *drv, CUdeviceptr ptr, NVSurface *surface, uint32_t pitch) {
-    int bpp = surface->format == cudaVideoSurfaceFormat_NV12 ? 1 : 2;
-    CUDA_MEMCPY2D cpy = {
-        .srcMemoryType = CU_MEMORYTYPE_DEVICE,
-        .srcDevice = ptr,
-        .srcPitch = pitch,
-        .dstMemoryType = CU_MEMORYTYPE_ARRAY,
-        .dstArray = surface->backingImage->arrays[0],
-        .Height = surface->height,
-        .WidthInBytes = surface->width * bpp
-    };
-    CHECK_CUDA_RESULT_RETURN(drv->cu->cuMemcpy2DAsync(&cpy, 0), false);
-    CUDA_MEMCPY2D cpy2 = {
-        .srcMemoryType = CU_MEMORYTYPE_DEVICE,
-        .srcDevice = ptr,
-        .srcY = surface->height,
-        .srcPitch = pitch,
-        .dstMemoryType = CU_MEMORYTYPE_ARRAY,
-        .dstArray = surface->backingImage->arrays[1],
-        .Height = surface->height >> 1,
-        .WidthInBytes = surface->width * bpp
-    };
-    CHECK_CUDA_RESULT_RETURN(drv->cu->cuMemcpy2D(&cpy2), false);
+    BackingImage *img = surface->backingImage;
+    const NVFormatInfo *fmtInfo = &formatsInfo[img->format];
+    uint32_t y = 0;
+
+    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+        const NVFormatPlane *p = &fmtInfo->plane[i];
+        CUDA_MEMCPY2D cpy = {
+            .srcMemoryType = CU_MEMORYTYPE_DEVICE,
+            .srcDevice = ptr,
+            .srcY = y,
+            .srcPitch = pitch,
+            .dstMemoryType = CU_MEMORYTYPE_ARRAY,
+            .dstArray = surface->backingImage->arrays[i],
+            .Height = surface->height >> p->ss.y,
+            .WidthInBytes = (surface->width >> p->ss.x) * fmtInfo->bppc * p->channelCount
+        };
+        if (i == fmtInfo->numPlanes - 1) {
+            CHECK_CUDA_RESULT(drv->cu->cuMemcpy2D(&cpy));
+        } else {
+            CHECK_CUDA_RESULT(drv->cu->cuMemcpy2DAsync(&cpy, 0));
+        }
+        y += surface->height >> p->ss.y;
+    }
 
     //notify anyone waiting for us to be resolved
     pthread_mutex_lock(&surface->mutex);
@@ -293,33 +313,26 @@ bool direct_exportCudaPtr(NVDriver *drv, CUdeviceptr ptr, NVSurface *surface, ui
 
 bool direct_fillExportDescriptor(NVDriver *drv, NVSurface *surface, VADRMPRIMESurfaceDescriptor *desc) {
     BackingImage *img = surface->backingImage;
+    const NVFormatInfo *fmtInfo = &formatsInfo[img->format];
 
-    //TODO only support 420 images (either NV12, P010 or P012)
-    desc->fourcc = img->fourcc;
+    desc->fourcc = fmtInfo->fourcc;
     desc->width = surface->width;
     desc->height = surface->height;
-    desc->num_layers = 2;
-    desc->num_objects = 2;
 
-    desc->objects[0].fd = dup(img->fds[0]);
-    desc->objects[0].size = img->size[0];
-    desc->objects[0].drm_format_modifier = img->mods[0];
+    desc->num_layers = fmtInfo->numPlanes;
+    desc->num_objects = fmtInfo->numPlanes;
 
-    desc->objects[1].fd = dup(img->fds[1]);
-    desc->objects[1].size = img->size[1];
-    desc->objects[1].drm_format_modifier = img->mods[1];
+    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+        desc->objects[i].fd = dup(img->fds[i]);
+        desc->objects[i].size = img->size[i];
+        desc->objects[i].drm_format_modifier = img->mods[i];
 
-    desc->layers[0].drm_format = img->fourcc == DRM_FORMAT_NV12 ? DRM_FORMAT_R8 : DRM_FORMAT_R16;
-    desc->layers[0].num_planes = 1;
-    desc->layers[0].object_index[0] = 0;
-    desc->layers[0].offset[0] = img->offsets[0];
-    desc->layers[0].pitch[0] = img->strides[0];
-
-    desc->layers[1].drm_format = img->fourcc == DRM_FORMAT_NV12 ? DRM_FORMAT_RG88 : DRM_FORMAT_RG1616;
-    desc->layers[1].num_planes = 1;
-    desc->layers[1].object_index[0] = 1;
-    desc->layers[1].offset[0] = img->offsets[1];
-    desc->layers[1].pitch[0] = img->strides[1];
+        desc->layers[i].drm_format = fmtInfo->plane[i].fourcc;
+        desc->layers[i].num_planes = 1;
+        desc->layers[i].object_index[0] = i;
+        desc->layers[i].offset[0] = img->offsets[i];
+        desc->layers[i].pitch[0] = img->strides[i];
+    }
 
     return true;
 }

--- a/src/direct/direct-export-buf.c
+++ b/src/direct/direct-export-buf.c
@@ -152,13 +152,13 @@ BackingImage *direct_allocateBackingImage(NVDriver *drv, const NVSurface *surfac
     p = fmtInfo->plane;
 
     LOG("Allocating BackingImages: %p %dx%d", backingImage, surface->width, surface->height);
-    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+    for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
         alloc_image(&drv->driverContext, surface->width >> p[i].ss.x, surface->height >> p[i].ss.y,
             p[i].channelCount, 8 * fmtInfo->bppc, p[i].fourcc, &driverImages[i]);
     }
 
     LOG("Importing images");
-    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+    for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
         if (!import_to_cuda(drv, &driverImages[i], 8 * fmtInfo->bppc, p[i].channelCount, &backingImage->cudaImages[i], &backingImage->arrays[i]))
             goto bail;
     }
@@ -166,7 +166,7 @@ BackingImage *direct_allocateBackingImage(NVDriver *drv, const NVSurface *surfac
     backingImage->width = surface->width;
     backingImage->height = surface->height;
 
-    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+    for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
         backingImage->fds[i] = driverImages[i].drmFd;
         backingImage->strides[i] = driverImages[i].pitch;
         backingImage->mods[i] = driverImages[i].mods;
@@ -176,7 +176,7 @@ BackingImage *direct_allocateBackingImage(NVDriver *drv, const NVSurface *surfac
     return backingImage;
 
 bail:
-    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+    for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
         if (driverImages[i].nvFd != 0) {
             close(driverImages[i].nvFd);
         }
@@ -204,7 +204,7 @@ static void destroyBackingImage(NVDriver *drv, BackingImage *img) {
         }
     }
 
-    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+    for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
         if (img->arrays[i] != NULL) {
             CHECK_CUDA_RESULT(drv->cu->cuArrayDestroy(img->arrays[i]));
         }
@@ -247,7 +247,7 @@ static bool copyFrameToSurface(NVDriver *drv, CUdeviceptr ptr, NVSurface *surfac
     const NVFormatInfo *fmtInfo = &formatsInfo[img->format];
     uint32_t y = 0;
 
-    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+    for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
         const NVFormatPlane *p = &fmtInfo->plane[i];
         CUDA_MEMCPY2D cpy = {
             .srcMemoryType = CU_MEMORYTYPE_DEVICE,
@@ -322,7 +322,7 @@ bool direct_fillExportDescriptor(NVDriver *drv, NVSurface *surface, VADRMPRIMESu
     desc->num_layers = fmtInfo->numPlanes;
     desc->num_objects = fmtInfo->numPlanes;
 
-    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+    for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
         desc->objects[i].fd = dup(img->fds[i]);
         desc->objects[i].size = img->size[i];
         desc->objects[i].drm_format_modifier = img->mods[i];

--- a/src/direct/nv-driver.c
+++ b/src/direct/nv-driver.c
@@ -389,7 +389,7 @@ bool alloc_memory(NVDriverContext *context, uint32_t size, int *fd) {
     return false;
 }
 
-bool alloc_image(NVDriverContext *context, uint32_t width, uint32_t height, uint8_t channels, uint8_t bitsPerChannel, NVDriverImage *image) {
+bool alloc_image(NVDriverContext *context, uint32_t width, uint32_t height, uint8_t channels, uint8_t bitsPerChannel, uint32_t fourcc, NVDriverImage *image) {
     uint32_t depth = 1;
     uint32_t gobWidthInBytes = 64;
     uint32_t gobHeightInBytes = 8;
@@ -495,14 +495,7 @@ bool alloc_image(NVDriverContext *context, uint32_t width, uint32_t height, uint
     image->offset = 0;
     image->pitch = widthInBytes;
     image->memorySize = imageSizeInBytes;
-    if (channels == 1) {
-        image->fourcc = bytesPerChannel == 1 ? DRM_FORMAT_R8 : DRM_FORMAT_R16;
-    } else if (channels == 2) {
-        image->fourcc = bytesPerChannel == 1 ? DRM_FORMAT_RG88 : DRM_FORMAT_RG1616;
-    } else {
-        LOG("Unknown fourcc");
-        return false;
-    }
+    image->fourcc = fourcc;
 
     LOG("created image: %dx%d %lx %d %x", width, height, image->mods, widthInBytes, imageSizeInBytes);
 

--- a/src/direct/nv-driver.h
+++ b/src/direct/nv-driver.h
@@ -36,6 +36,6 @@ bool init_nvdriver(NVDriverContext *context, int drmFd);
 bool free_nvdriver(NVDriverContext *context);
 bool get_device_uuid(NVDriverContext *context, char uuid[16]);
 bool alloc_memory(NVDriverContext *context, uint32_t size, int *fd);
-bool alloc_image(NVDriverContext *context, uint32_t width, uint32_t height, uint8_t channels, uint8_t bytesPerChannel, NVDriverImage *image);
+bool alloc_image(NVDriverContext *context, uint32_t width, uint32_t height, uint8_t channels, uint8_t bytesPerChannel, uint32_t fourcc, NVDriverImage *image);
 
 #endif

--- a/src/export-buf.c
+++ b/src/export-buf.c
@@ -266,6 +266,7 @@ bool egl_initExporter(NVDriver *drv) {
             }
         }
         drv->supports16BitSurface = r16 & rg1616;
+        drv->supports444Surface = false;
         if (drv->supports16BitSurface) {
             LOG("Driver supports 16-bit surfaces");
         } else {

--- a/src/hevc.c
+++ b/src/hevc.c
@@ -295,6 +295,9 @@ static cudaVideoCodec computeHEVCCudaCodec(VAProfile profile) {
         case VAProfileHEVCMain:
         case VAProfileHEVCMain10:
         case VAProfileHEVCMain12:
+        case VAProfileHEVCMain444:
+        case VAProfileHEVCMain444_10:
+        case VAProfileHEVCMain444_12:
             return cudaVideoCodec_HEVC;
         default:
             return cudaVideoCodec_NONE;
@@ -305,6 +308,9 @@ static const VAProfile hevcSupportedProfiles[] = {
     VAProfileHEVCMain,
     VAProfileHEVCMain10,
     VAProfileHEVCMain12,
+    VAProfileHEVCMain444,
+    VAProfileHEVCMain444_10,
+    VAProfileHEVCMain444_12,
 };
 
 const DECLARE_CODEC(hevcCodec) = {

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -1481,7 +1481,7 @@ static VAStatus nvCreateImage(
     NVBuffer *imageBuffer = (NVBuffer*) imageBufferObject->obj;
     imageBuffer->bufferType = VAImageBufferType;
     imageBuffer->size = 0;
-    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+    for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
         imageBuffer->size += ((width * height) >> (p[i].ss.x + p[i].ss.y)) * fmtInfo->bppc * p[i].channelCount;
     }
     imageBuffer->elements = 1;
@@ -1597,7 +1597,7 @@ static VAStatus nvGetImage(
     //wait for the surface to be decoded
     nvSyncSurface(ctx, surface);
 
-    for (int i = 0; i < fmtInfo->numPlanes; i++) {
+    for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
         const NVFormatPlane *p = &fmtInfo->plane[i];
         CUDA_MEMCPY2D memcpy2d = {
         .srcXInBytes = 0, .srcY = 0,
@@ -1856,21 +1856,21 @@ static VAStatus nvQuerySurfaceAttributes(
                     attrib_idx += 1;
                     break;
                 case cudaVideoSurfaceFormat_YUV444_16Bit:
-#if VA_FOURCC_Q410
+#ifdef VA_FOURCC_Q410
                     attrib_list[attrib_idx].type = VASurfaceAttribPixelFormat;
                     attrib_list[attrib_idx].flags = 0;
                     attrib_list[attrib_idx].value.type = VAGenericValueTypeInteger;
                     attrib_list[attrib_idx].value.value.i = VA_FOURCC_Q410;
                     attrib_idx += 1;
 #endif
-#if VA_FOURCC_Q412
+#ifdef VA_FOURCC_Q412
                     attrib_list[attrib_idx].type = VASurfaceAttribPixelFormat;
                     attrib_list[attrib_idx].flags = 0;
                     attrib_list[attrib_idx].value.type = VAGenericValueTypeInteger;
                     attrib_list[attrib_idx].value.value.i = VA_FOURCC_Q412;
                     attrib_idx += 1;
 #endif
-#if VA_FOURCC_Q416
+#ifdef VA_FOURCC_Q416
                     attrib_list[attrib_idx].type = VASurfaceAttribPixelFormat;
                     attrib_list[attrib_idx].flags = 0;
                     attrib_list[attrib_idx].value.type = VAGenericValueTypeInteger;

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -52,6 +52,7 @@ const NVFormatInfo formatsInfo[] =
     [NV_FORMAT_P012] = {2, 2, DRM_FORMAT_P012,     true,  false, {{1, DRM_FORMAT_R16,      {0,0}}, {2, DRM_FORMAT_RG1616, {1,1}}},                            {VA_FOURCC_P012, VA_LSB_FIRST,   24, 0,0,0,0,0}},
     [NV_FORMAT_P016] = {2, 2, DRM_FORMAT_P016,     true,  false, {{1, DRM_FORMAT_R16,      {0,0}}, {2, DRM_FORMAT_RG1616, {1,1}}},                            {VA_FOURCC_P016, VA_LSB_FIRST,   24, 0,0,0,0,0}},
     [NV_FORMAT_444P] = {1, 3, DRM_FORMAT_YUV444,   false, true,  {{1, DRM_FORMAT_R8,       {0,0}}, {1, DRM_FORMAT_R8,     {0,0}}, {1, DRM_FORMAT_R8, {0,0}}}, {VA_FOURCC_444P, VA_LSB_FIRST,   24, 0,0,0,0,0}},
+    [NV_FORMAT_RGBP] = {1, 3, DRM_FORMAT_YUV444,   false, true,  {{1, DRM_FORMAT_R8,       {0,0}}, {1, DRM_FORMAT_R8,     {0,0}}, {1, DRM_FORMAT_R8, {0,0}}}, {VA_FOURCC_RGBP, VA_LSB_FIRST,   24, 0,0,0,0,0}},
     // Nvidia decoder only supports YUV444 planar formats with 3 planes so we can't use VA_FOURCC_Y410, VA_FOURCC_Y412 and VA_FOURCC_Y416.
     // VA_FOURCC_Q410, VA_FOURCC_Q412 and VA_FOURCC_Q416 aren't defined in va.h yet.
 #if defined(VA_FOURCC_Q410) && defined(DRM_FORMAT_Q410)
@@ -596,7 +597,7 @@ static VAStatus nvGetConfigAttributes(
                 // Fall-through
             case VAProfileHEVCMain444:
             case VAProfileVP9Profile1:
-                attrib_list[i].value |= VA_RT_FORMAT_YUV444;
+                attrib_list[i].value |= VA_RT_FORMAT_YUV444 | VA_RT_FORMAT_RGBP;
                 break;
             }
 
@@ -604,7 +605,7 @@ static VAStatus nvGetConfigAttributes(
                 attrib_list[i].value &= ~(VA_RT_FORMAT_YUV420_10 | VA_RT_FORMAT_YUV420_12 | VA_RT_FORMAT_YUV444_10 | VA_RT_FORMAT_YUV444_12);
             }
             if (!drv->supports444Surface) {
-                attrib_list[i].value &= ~(VA_RT_FORMAT_YUV444 | VA_RT_FORMAT_YUV444_10 | VA_RT_FORMAT_YUV444_12);
+                attrib_list[i].value &= ~(VA_RT_FORMAT_YUV444 | VA_RT_FORMAT_RGBP | VA_RT_FORMAT_YUV444_10 | VA_RT_FORMAT_YUV444_12);
             }
         }
         else if (attrib_list[i].type == VAConfigAttribMaxPictureWidth)
@@ -748,6 +749,7 @@ static VAStatus nvCreateConfig(
                     cfg->bitDepth = 10;
                     break;
                 case VA_RT_FORMAT_YUV444:
+                case VA_RT_FORMAT_RGBP:
                     cfg->surfaceFormat = cudaVideoSurfaceFormat_YUV444;
                     cfg->chromaFormat = cudaVideoChromaFormat_444;
                     cfg->bitDepth = 8;
@@ -825,7 +827,7 @@ static VAStatus nvQueryConfigAttributes(
         // Fall-through
     case VAProfileHEVCMain444:
     case VAProfileVP9Profile1:
-        attrib_list[i].value |= VA_RT_FORMAT_YUV444;
+        attrib_list[i].value |= VA_RT_FORMAT_YUV444 | VA_RT_FORMAT_RGBP;
         break;
     }
 
@@ -833,7 +835,7 @@ static VAStatus nvQueryConfigAttributes(
         attrib_list[i].value &= ~(VA_RT_FORMAT_YUV420_10 | VA_RT_FORMAT_YUV420_12 | VA_RT_FORMAT_YUV444_10 | VA_RT_FORMAT_YUV444_12);
     }
     if (!drv->supports444Surface) {
-        attrib_list[i].value &= ~(VA_RT_FORMAT_YUV444 | VA_RT_FORMAT_YUV444_10 | VA_RT_FORMAT_YUV444_12);
+        attrib_list[i].value &= ~(VA_RT_FORMAT_YUV444 | VA_RT_FORMAT_RGBP | VA_RT_FORMAT_YUV444_10 | VA_RT_FORMAT_YUV444_12);
     }
 
     i++;
@@ -876,6 +878,7 @@ static VAStatus nvCreateSurfaces2(
         bitdepth = 12;
         break;
     case VA_RT_FORMAT_YUV444:
+    case VA_RT_FORMAT_RGBP:
         nvFormat = cudaVideoSurfaceFormat_YUV444;
         chromaFormat = cudaVideoChromaFormat_444;
         bitdepth = 8;
@@ -1765,7 +1768,7 @@ static VAStatus nvQuerySurfaceAttributes(
     }
 
     if (num_attribs != NULL) {
-        *num_attribs = 5;
+        *num_attribs = 6;
         if (drv->supports16BitSurface) {
             *num_attribs += 2;
         }
@@ -1811,6 +1814,11 @@ static VAStatus nvQuerySurfaceAttributes(
                     attrib_list[attrib_idx].flags = 0;
                     attrib_list[attrib_idx].value.type = VAGenericValueTypeInteger;
                     attrib_list[attrib_idx].value.value.i = VA_FOURCC_444P;
+                    attrib_idx += 1;
+                    attrib_list[attrib_idx].type = VASurfaceAttribPixelFormat;
+                    attrib_list[attrib_idx].flags = 0;
+                    attrib_list[attrib_idx].value.type = VAGenericValueTypeInteger;
+                    attrib_list[attrib_idx].value.value.i = VA_FOURCC_RGBP;
                     attrib_idx += 1;
                     break;
                 case cudaVideoSurfaceFormat_YUV444_16Bit:

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -68,11 +68,24 @@ typedef struct
     pthread_cond_t          cond;
 } NVSurface;
 
+typedef enum
+{
+    NV_FORMAT_NONE,
+    NV_FORMAT_NV12,
+    NV_FORMAT_P010,
+    NV_FORMAT_P012,
+    NV_FORMAT_P016,
+    NV_FORMAT_444P,
+    NV_FORMAT_Q410,
+    NV_FORMAT_Q412,
+    NV_FORMAT_Q416
+} NVFormat;
+
 typedef struct
 {
     int         width;
     int         height;
-    uint32_t    format;
+    NVFormat    format;
     NVBuffer    *imageBuffer;
 } NVImage;
 
@@ -84,7 +97,7 @@ typedef struct {
 typedef struct _BackingImage {
     NVSurface   *surface;
     EGLImage    image;
-    CUarray     arrays[2];
+    CUarray     arrays[3];
     uint32_t    width;
     uint32_t    height;
     int         fourcc;
@@ -94,7 +107,8 @@ typedef struct _BackingImage {
     uint64_t    mods[4];
     uint32_t    size[4];
     //direct backend only
-    NVCudaImage cudaImages[2];
+    NVCudaImage cudaImages[3];
+    NVFormat    format;
 } BackingImage;
 
 struct _NVDriver;
@@ -120,6 +134,7 @@ typedef struct _NVDriver
     VAGenericID             nextObjId;
     bool                    useCorrectNV12Format;
     bool                    supports16BitSurface;
+    bool                    supports444Surface;
     int                     cudaGpuId;
     int                     drmFd;
     int                     surfaceCount;
@@ -189,6 +204,32 @@ struct _NVCodec {
 };
 
 typedef struct _NVCodec NVCodec;
+
+typedef struct
+{
+    uint32_t x;
+    uint32_t y;
+} NVSubSampling;
+
+typedef struct
+{
+    uint32_t channelCount;
+    uint32_t fourcc;
+    NVSubSampling ss; // subsampling
+} NVFormatPlane;
+
+typedef struct
+{
+    uint32_t bppc; // bytes per pixel per channel
+    uint32_t numPlanes;
+    uint32_t fourcc;
+    bool     is16bits;
+    bool     isYuv444;
+    NVFormatPlane plane[3];
+    VAImageFormat vaFormat;
+} NVFormatInfo;
+
+extern const NVFormatInfo formatsInfo[];
 
 void appendBuffer(AppendableBuffer *ab, const void *buf, uint64_t size);
 int pictureIdxFromSurfaceId(NVDriver *ctx, VASurfaceID surf);

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -78,7 +78,8 @@ typedef enum
     NV_FORMAT_444P,
     NV_FORMAT_Q410,
     NV_FORMAT_Q412,
-    NV_FORMAT_Q416
+    NV_FORMAT_Q416,
+    NV_FORMAT_RGBP
 } NVFormat;
 
 typedef struct

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -78,8 +78,7 @@ typedef enum
     NV_FORMAT_444P,
     NV_FORMAT_Q410,
     NV_FORMAT_Q412,
-    NV_FORMAT_Q416,
-    NV_FORMAT_RGBP
+    NV_FORMAT_Q416
 } NVFormat;
 
 typedef struct


### PR DESCRIPTION
I added `yuv444` decoding support and refactored color format into a static list `formatsInfo` to easily add a new one if needed. I also added `yuv444p10`, `yuv444p12` and `yuv444p16` but currently VAAPI doesn't expose theses formats.
To support YUV444 on any FFmpeg based program the commit https://github.com/FFmpeg/FFmpeg/commit/d3f48e68b3236bc3fbf75cc489d53e9f397f5e0a is needed otherwise it will fallback to software decoder even if `vainfo` lists `VAProfileHEVCMain444`.

YUV444 is only supported on HEVC codec and Turing architecture (RTX 2000/GTX 1600) or newer is needed.