### PR TITLE
meson: properly check for libva, add libdrm dependency

### DIFF
--- a/extract_headers.sh
+++ b/extract_headers.sh
@@ -50,5 +50,5 @@ done
 
 #fixup nvidia-drm-ioctl.h as it includes a kernel header, and we'd like it to be able to choose
 mv ${OUTPUT_DIR}/nvidia-drm-ioctl.h ${OUTPUT_DIR}/nvidia-drm-ioctl.h.bak
-sed 's$#include <drm/drm.h>$#if defined __has_include \&\& __has_include(<libdrm/drm.h>)\n#  include <libdrm/drm.h>\n#else\n#  include <drm/drm.h>\n#endif$' < ${OUTPUT_DIR}/nvidia-drm-ioctl.h.bak > ${OUTPUT_DIR}/nvidia-drm-ioctl.h
+sed 's$#include <drm/drm.h>$#include <drm.h>$' < ${OUTPUT_DIR}/nvidia-drm-ioctl.h.bak > ${OUTPUT_DIR}/nvidia-drm-ioctl.h
 

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ deps = [
     cc.find_library('EGL'),
     dependency('ffnvcodec', version: '>= 11.1.5.1'),
     dependency('libva', version: '>= 1.8.0').partial_dependency(compile_args: true),
+    dependency('libdrm', version: '>=2.4.60').partial_dependency(compile_args: true),
     dependency('threads'),
 ]
 gst_codecs_deps = dependency('gstreamer-codecparsers-1.0', required: false)

--- a/meson.build
+++ b/meson.build
@@ -13,13 +13,15 @@ project(
 
 cc = meson.get_compiler('c')
 
-m_dep = cc.find_library('m')
-dl_dep = cc.find_library('dl', required : false)
-egl_dep = cc.find_library('EGL')
+deps = [
+    cc.find_library('m'),
+    cc.find_library('dl', required : false),
+    cc.find_library('EGL'),
+    dependency('ffnvcodec', version: '>= 11.1.5.1'),
+    dependency('libva', version: '>= 1.8.0')
+    dependency('threads'),
+]
 gst_codecs_deps = dependency('gstreamer-codecparsers-1.0', required: false)
-ffnvcodec_deps = dependency('ffnvcodec', version: '>= 11.1.5.1')
-libva_deps = dependency('libva', version: '>= 1.8.0')
-thread_dep = dependency('threads')
 
 sources = [
     'src/av1.c',
@@ -39,7 +41,8 @@ sources = [
 ]
 
 if gst_codecs_deps.found()
-    sources += ['src/vp9.c',]
+    sources += ['src/vp9.c']
+    deps += [gst_codecs_deps]
 endif
 
 nvidia_incdir = include_directories('nvidia-include')
@@ -48,15 +51,7 @@ shared_library(
     'nvidia_drv_video',
     name_prefix: '',
     sources: sources,
-    dependencies: [
-        libva_deps,
-        ffnvcodec_deps,
-        gst_codecs_deps,
-        egl_dep,
-        m_dep,
-        dl_dep,
-        thread_dep,
-    ],
+    dependencies: deps,
     include_directories: nvidia_incdir,
     install: true,
     install_dir: get_option('libdir') / 'dri',

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ deps = [
     cc.find_library('dl', required : false),
     cc.find_library('EGL'),
     dependency('ffnvcodec', version: '>= 11.1.5.1'),
-    dependency('libva', version: '>= 1.8.0')
+    dependency('libva', version: '>= 1.8.0').partial_dependency(compile_args: true),
     dependency('threads'),
 ]
 gst_codecs_deps = dependency('gstreamer-codecparsers-1.0', required: false)

--- a/nvidia-include/nvidia-drm-ioctl.h
+++ b/nvidia-include/nvidia-drm-ioctl.h
@@ -23,11 +23,7 @@
 #ifndef _UAPI_NVIDIA_DRM_IOCTL_H_
 #define _UAPI_NVIDIA_DRM_IOCTL_H_
 
-#if defined __has_include && __has_include(<libdrm/drm.h>)
-#  include <libdrm/drm.h>
-#else
-#  include <drm/drm.h>
-#endif
+#include <drm.h>
 
 /*
  * We should do our best to keep these values constant. Any change to these will

--- a/src/direct/direct-export-buf.c
+++ b/src/direct/direct-export-buf.c
@@ -11,13 +11,8 @@
 #include <string.h>
 #include "../backend-common.h"
 
-#if defined __has_include && __has_include(<libdrm/drm.h>)
-#  include <libdrm/drm.h>
-#  include <libdrm/drm_fourcc.h>
-#else
-#  include <drm/drm.h>
-#  include <drm/drm_fourcc.h>
-#endif
+#include <drm.h>
+#include <drm_fourcc.h>
 
 void findGPUIndexFromFd(NVDriver *drv) {
     //find the CUDA device id

--- a/src/direct/nv-driver.c
+++ b/src/direct/nv-driver.c
@@ -9,11 +9,7 @@
 #include <stdint.h>
 #include <errno.h>
 
-#if defined __has_include && __has_include(<libdrm/drm.h>)
-#  include <libdrm/drm_fourcc.h>
-#else
-#  include <drm/drm_fourcc.h>
-#endif
+#include <drm_fourcc.h>
 
 #include "nv-driver.h"
 #include <nvidia.h>

--- a/src/export-buf.c
+++ b/src/export-buf.c
@@ -10,13 +10,8 @@
 #include <unistd.h>
 #include <sys/sysmacros.h>
 
-#if defined __has_include && __has_include(<libdrm/drm.h>)
-#  include <libdrm/drm.h>
-#  include <libdrm/drm_fourcc.h>
-#else
-#  include <drm/drm.h>
-#  include <drm/drm_fourcc.h>
-#endif
+#include <drm.h>
+#include <drm_fourcc.h>
 
 #ifndef EGL_NV_stream_consumer_eglimage
 #define EGL_NV_stream_consumer_eglimage 1

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -15,11 +15,7 @@
 #include <va/va_backend.h>
 #include <va/va_drmcommon.h>
 
-#if defined __has_include && __has_include(<libdrm/drm.h>)
-#  include <libdrm/drm_fourcc.h>
-#else
-#  include <drm/drm_fourcc.h>
-#endif
+#include <drm_fourcc.h>
 
 #include <unistd.h>
 #include <sys/types.h>


### PR DESCRIPTION
Greetings everyone,

Here we group the dependencies, annotate libva as partial (compile-only) dependency + add the missing libdrm (again partial compile-only) dependency to the list.

First commit is cosmetic, while the latter two remove over-linking and misc include hacks.