### PR TITLE
Fix CUDA_ERROR_INVALID_CONTEXT from cuMemcpy2D

### DIFF
--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -1571,6 +1571,7 @@ static VAStatus nvGetImage(
     //wait for the surface to be decoded
     nvSyncSurface(ctx, surface);
 
+    CHECK_CUDA_RESULT_RETURN(cu->cuCtxPushCurrent(drv->cudaContext), VA_STATUS_ERROR_OPERATION_FAILED);
     for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
         const NVFormatPlane *p = &fmtInfo->plane[i];
         CUDA_MEMCPY2D memcpy2d = {
@@ -1595,6 +1596,7 @@ static VAStatus nvGetImage(
         }
         offset += ((width * height) >> (p->ss.x + p->ss.y)) * fmtInfo->bppc * p->channelCount;
     }
+    CHECK_CUDA_RESULT_RETURN(cu->cuCtxPopCurrent(NULL), VA_STATUS_ERROR_OPERATION_FAILED);
 
     return VA_STATUS_SUCCESS;
 }


### PR DESCRIPTION
Video deinterlacing in `mpv` fails because of missing VAAPI profile then it fallbacks to software filter and fails again on `cuMemcpy2D` with CUDA_ERROR_INVALID_CONTEXT (error 201) when downloading frames from CUDA:

```
     18365.227291870 [35491-35491] ../nvidia-vaapi-driver-0.0.9/src/vabackend.c: 647           nvCreateConfig got profile: -1 with 0 attributes
     18365.227305272 [35491-35491] ../nvidia-vaapi-driver-0.0.9/src/vabackend.c: 652           nvCreateConfig Profile not supported: -1

[vavpp] vaCreateConfig() failed (the requested VAProfile is not supported)
[deint] Creating filter 'vavpp' failed.
[deint]      18365.227330081 [35491-35501] ../nvidia-vaapi-driver-0.0.9/src/vabackend.c:2052    nvExportSurfaceHandle Exporting surface: 3 (0x55e3526c8f10)
     18365.227342665 [35491-35501] ../nvidia-vaapi-driver-0.0.9/src/vabackend.c:2065    nvExportSurfaceHandle Exporting with 1440 1080 0 1472 3000000004fe014 0 1472 3000000004fe014
creating deinterlacer failed
[autoconvert] HW-downloading from vaapi
     18365.233274434 [35491-35491] ../nvidia-vaapi-driver-0.0.9/src/vabackend.c:1444            nvCreateImage created image id: 162
     18365.233289783 [35491-35491] ../nvidia-vaapi-driver-0.0.9/src/vabackend.c:1592               nvGetImage cuMemcpy2D failed: 201
[ffmpeg] AVHWFramesContext: Failed to read image from surface 0xf: 23 (internal decoding error).
[hwdownload] Could not copy hardware frame to CPU memory.
[ffmpeg] Impossible to convert between the formats supported by the filter 'mpv_src_default_in' and the filter 'auto_scale_0'
[lavfi] failed to configure the filter graph
Disabling filter userdeint because it has failed.
```

The pull request fixes the issue.