### PR TITLE
Update README.md, remind about ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Environment variables used to control the behavior of this library.
 
 ## Firefox
 
-To use the driver with firefox you will need at least Firefox 96, the following config options need to be set in the `about:config` page:
+To use the driver with firefox you will need at least Firefox 96, `ffmpeg` compiled with vaapi support (search ffmpeg output for --enable-vaapi), and the following config options need to be set in the `about:config` page:
 
 | Option | Value | Reason |
 |---|---|---|


### PR DESCRIPTION
Relevant for Gentoo builds, it needs USE=vaapi or Firefox won't try using vaapi.