### PR TITLE
Use libva's driverdir path instead hardcoded

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,10 +18,12 @@ deps = [
     cc.find_library('dl', required : false),
     dependency('egl'),
     dependency('ffnvcodec', version: '>= 11.1.5.1'),
-    dependency('libva', version: '>= 1.8.0').partial_dependency(compile_args: true),
     dependency('libdrm', version: '>=2.4.60').partial_dependency(compile_args: true),
     dependency('threads'),
 ]
+libva_deps = dependency('libva', version: '>= 1.8.0').partial_dependency(compile_args: true)
+deps += [libva_deps]
+
 gst_codecs_deps = dependency('gstreamer-codecparsers-1.0', required: false)
 
 if cc.get_argument_syntax() == 'gcc'
@@ -69,6 +71,7 @@ if gst_codecs_deps.found()
 endif
 
 nvidia_incdir = include_directories('nvidia-include')
+nvidia_install_dir = libva_deps.get_variable(pkgconfig: 'driverdir')
 
 shared_library(
     'nvidia_drv_video',
@@ -77,7 +80,7 @@ shared_library(
     dependencies: deps,
     include_directories: nvidia_incdir,
     install: true,
-    install_dir: get_option('libdir') / 'dri',
+    install_dir: nvidia_install_dir,
     gnu_symbol_visibility: 'hidden',
 )
 


### PR DESCRIPTION
In some systems libva may expects driver location in different path. Reusing driverdir variable from pkg-config to provide correct one.