### PR TITLE
Fix YUV444 10 and 12 bits

### DIFF
--- a/src/direct/direct-export-buf.c
+++ b/src/direct/direct-export-buf.c
@@ -170,17 +170,7 @@ static BackingImage *direct_allocateBackingImage(NVDriver *drv, const NVSurface 
         break;
 
     case cudaVideoSurfaceFormat_YUV444_16Bit:
-        switch (surface->bitDepth) {
-        case 10:
-            backingImage->format = NV_FORMAT_Q410;
-            break;
-        case 12:
-            backingImage->format = NV_FORMAT_Q412;
-            break;
-        default:
-            backingImage->format = NV_FORMAT_Q416;
-            break;
-        }
+        backingImage->format = NV_FORMAT_Q416;
         break;
 
     case cudaVideoSurfaceFormat_YUV444:

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -54,9 +54,7 @@ const NVFormatInfo formatsInfo[] =
     [NV_FORMAT_P012] = {2, 2, DRM_FORMAT_P012,     true,  false, {{1, DRM_FORMAT_R16,      {0,0}}, {2, DRM_FORMAT_RG1616, {1,1}}},                            {VA_FOURCC_P012, VA_LSB_FIRST,   24, 0,0,0,0,0}},
     [NV_FORMAT_P016] = {2, 2, DRM_FORMAT_P016,     true,  false, {{1, DRM_FORMAT_R16,      {0,0}}, {2, DRM_FORMAT_RG1616, {1,1}}},                            {VA_FOURCC_P016, VA_LSB_FIRST,   24, 0,0,0,0,0}},
     [NV_FORMAT_444P] = {1, 3, DRM_FORMAT_YUV444,   false, true,  {{1, DRM_FORMAT_R8,       {0,0}}, {1, DRM_FORMAT_R8,     {0,0}}, {1, DRM_FORMAT_R8, {0,0}}}, {VA_FOURCC_444P, VA_LSB_FIRST,   24, 0,0,0,0,0}},
-    // Nvidia decoder only supports YUV444 planar formats with 3 planes so we can't use VA_FOURCC_Y416.
-    // VA_FOURCC_Q416 isn't defined in va.h yet.
-#if defined(VA_FOURCC_Q416)
+#if VA_CHECK_VERSION(1, 20, 0)
     [NV_FORMAT_Q416] = {2, 3, DRM_FORMAT_INVALID,  true,  true,  {{1, DRM_FORMAT_R16,      {0,0}}, {1, DRM_FORMAT_R16,    {0,0}}, {1, DRM_FORMAT_R16,{0,0}}}, {VA_FOURCC_Q416, VA_LSB_FIRST,   48, 0,0,0,0,0}},
 #endif
 };
@@ -499,8 +497,7 @@ static VAStatus nvQueryConfigProfiles(
             profile_list[profiles++] = VAProfileAV1Profile1;
         }
 
-    // Currently VAAPI doesn't support yuv444p10 yuv444p12 and yuv444p16
-#if defined(VA_FOURCC_Q416)
+#if VA_CHECK_VERSION(1, 20, 0)
         if (drv->supports16BitSurface) {
             if (doesGPUSupportCodec(cudaVideoCodec_HEVC, 10, cudaVideoChromaFormat_444, NULL, NULL)) {
                 profile_list[profiles++] = VAProfileHEVCMain444_10;
@@ -1778,7 +1775,7 @@ static VAStatus nvQuerySurfaceAttributes(
         int cnt = 4;
         if (cfg->chromaFormat == cudaVideoChromaFormat_444) {
             cnt += 1;
-#ifdef VA_FOURCC_Q416
+#if VA_CHECK_VERSION(1, 20, 0)
             cnt += 1;
 #endif
         } else {
@@ -1834,7 +1831,7 @@ static VAStatus nvQuerySurfaceAttributes(
             attrib_list[attrib_idx].value.type = VAGenericValueTypeInteger;
             attrib_list[attrib_idx].value.value.i = VA_FOURCC_444P;
             attrib_idx += 1;
-#ifdef VA_FOURCC_Q416
+#if VA_CHECK_VERSION(1, 20, 0)
             attrib_list[attrib_idx].type = VASurfaceAttribPixelFormat;
             attrib_list[attrib_idx].flags = 0;
             attrib_list[attrib_idx].value.type = VAGenericValueTypeInteger;

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -54,16 +54,10 @@ const NVFormatInfo formatsInfo[] =
     [NV_FORMAT_P012] = {2, 2, DRM_FORMAT_P012,     true,  false, {{1, DRM_FORMAT_R16,      {0,0}}, {2, DRM_FORMAT_RG1616, {1,1}}},                            {VA_FOURCC_P012, VA_LSB_FIRST,   24, 0,0,0,0,0}},
     [NV_FORMAT_P016] = {2, 2, DRM_FORMAT_P016,     true,  false, {{1, DRM_FORMAT_R16,      {0,0}}, {2, DRM_FORMAT_RG1616, {1,1}}},                            {VA_FOURCC_P016, VA_LSB_FIRST,   24, 0,0,0,0,0}},
     [NV_FORMAT_444P] = {1, 3, DRM_FORMAT_YUV444,   false, true,  {{1, DRM_FORMAT_R8,       {0,0}}, {1, DRM_FORMAT_R8,     {0,0}}, {1, DRM_FORMAT_R8, {0,0}}}, {VA_FOURCC_444P, VA_LSB_FIRST,   24, 0,0,0,0,0}},
-    // Nvidia decoder only supports YUV444 planar formats with 3 planes so we can't use VA_FOURCC_Y410, VA_FOURCC_Y412 and VA_FOURCC_Y416.
-    // VA_FOURCC_Q410, VA_FOURCC_Q412 and VA_FOURCC_Q416 aren't defined in va.h yet.
-#if defined(VA_FOURCC_Q410) && defined(DRM_FORMAT_Q410)
-    [NV_FORMAT_Q410] = {2, 3, DRM_FORMAT_Q410,     true,  true,  {{1, DRM_FORMAT_R16,      {0,0}}, {1, DRM_FORMAT_R16,    {0,0}}, {1, DRM_FORMAT_R16,{0,0}}}, {VA_FOURCC_Q410, VA_LSB_FIRST,   48, 0,0,0,0,0}},
-#endif
-#if defined(VA_FOURCC_Q412) && defined(DRM_FORMAT_Q412)
-    [NV_FORMAT_Q412] = {2, 3, DRM_FORMAT_Q412,     true,  true,  {{1, DRM_FORMAT_R16,      {0,0}}, {1, DRM_FORMAT_R16,    {0,0}}, {1, DRM_FORMAT_R16,{0,0}}}, {VA_FOURCC_Q412, VA_LSB_FIRST,   48, 0,0,0,0,0}},
-#endif
-#if defined(VA_FOURCC_Q416) && defined(DRM_FORMAT_Q416)
-    [NV_FORMAT_Q416] = {2, 3, DRM_FORMAT_Q416,     true,  true,  {{1, DRM_FORMAT_R16,      {0,0}}, {1, DRM_FORMAT_R16,    {0,0}}, {1, DRM_FORMAT_R16,{0,0}}}, {VA_FOURCC_Q416, VA_LSB_FIRST,   48, 0,0,0,0,0}},
+    // Nvidia decoder only supports YUV444 planar formats with 3 planes so we can't use VA_FOURCC_Y416.
+    // VA_FOURCC_Q416 isn't defined in va.h yet.
+#if defined(VA_FOURCC_Q416)
+    [NV_FORMAT_Q416] = {2, 3, DRM_FORMAT_INVALID,  true,  true,  {{1, DRM_FORMAT_R16,      {0,0}}, {1, DRM_FORMAT_R16,    {0,0}}, {1, DRM_FORMAT_R16,{0,0}}}, {VA_FOURCC_Q416, VA_LSB_FIRST,   48, 0,0,0,0,0}},
 #endif
 };
 
@@ -506,16 +500,14 @@ static VAStatus nvQueryConfigProfiles(
         }
 
     // Currently VAAPI doesn't support yuv444p10 yuv444p12 and yuv444p16
-#if defined(VA_FOURCC_Q410) && defined(DRM_FORMAT_Q410)
+#if defined(VA_FOURCC_Q416)
         if (drv->supports16BitSurface) {
             if (doesGPUSupportCodec(cudaVideoCodec_HEVC, 10, cudaVideoChromaFormat_444, NULL, NULL)) {
                 profile_list[profiles++] = VAProfileHEVCMain444_10;
             }
-#if (defined(VA_FOURCC_Q412) && defined(DRM_FORMAT_Q412)) || (defined(VA_FOURCC_Q416) && defined(DRM_FORMAT_Q416))
             if (doesGPUSupportCodec(cudaVideoCodec_HEVC, 12, cudaVideoChromaFormat_444, NULL, NULL)) {
                 profile_list[profiles++] = VAProfileHEVCMain444_12;
             }
-#endif
             if (doesGPUSupportCodec(cudaVideoCodec_VP9, 10, cudaVideoChromaFormat_444, NULL, NULL)) {
                 profile_list[profiles++] = VAProfileVP9Profile3; //color depth: 10–12 bit, 4:2:2, 4:4:0, 4:4:4
             }
@@ -1786,12 +1778,6 @@ static VAStatus nvQuerySurfaceAttributes(
         int cnt = 4;
         if (cfg->chromaFormat == cudaVideoChromaFormat_444) {
             cnt += 1;
-#ifdef VA_FOURCC_Q410
-            cnt += 1;
-#endif
-#ifdef VA_FOURCC_Q412
-            cnt += 1;
-#endif
 #ifdef VA_FOURCC_Q416
             cnt += 1;
 #endif
@@ -1848,20 +1834,6 @@ static VAStatus nvQuerySurfaceAttributes(
             attrib_list[attrib_idx].value.type = VAGenericValueTypeInteger;
             attrib_list[attrib_idx].value.value.i = VA_FOURCC_444P;
             attrib_idx += 1;
-#ifdef VA_FOURCC_Q410
-            attrib_list[attrib_idx].type = VASurfaceAttribPixelFormat;
-            attrib_list[attrib_idx].flags = 0;
-            attrib_list[attrib_idx].value.type = VAGenericValueTypeInteger;
-            attrib_list[attrib_idx].value.value.i = VA_FOURCC_Q410;
-            attrib_idx += 1;
-#endif
-#ifdef VA_FOURCC_Q412
-            attrib_list[attrib_idx].type = VASurfaceAttribPixelFormat;
-            attrib_list[attrib_idx].flags = 0;
-            attrib_list[attrib_idx].value.type = VAGenericValueTypeInteger;
-            attrib_list[attrib_idx].value.value.i = VA_FOURCC_Q412;
-            attrib_idx += 1;
-#endif
 #ifdef VA_FOURCC_Q416
             attrib_list[attrib_idx].type = VASurfaceAttribPixelFormat;
             attrib_list[attrib_idx].flags = 0;

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -76,8 +76,6 @@ typedef enum
     NV_FORMAT_P012,
     NV_FORMAT_P016,
     NV_FORMAT_444P,
-    NV_FORMAT_Q410,
-    NV_FORMAT_Q412,
     NV_FORMAT_Q416
 } NVFormat;
 


### PR DESCRIPTION
NVIDIA driver uses 16 bits surfaces for YUV 444 10 and 12 bits decoding.
VA_FOURCC_Q410 (yuv444p10), VA_FOURCC_Q412 (yuv444p12) formats lead to invalid video output, so I only kept VA_FOURCC_Q416 (yuv444p16).

To test these formats, I patched `ffmpeg` and `libva` with following files:

`ffmpeg` 6.0:
```diff
diff --git a/libavcodec/vaapi_decode.c b/libavcodec/vaapi_decode.c
index 134f10eca5..af95b94caa 100644
--- a/libavcodec/vaapi_decode.c
+++ b/libavcodec/vaapi_decode.c
@@ -289,6 +289,9 @@ static const struct {
 #ifdef VA_FOURCC_I010
     MAP(I010, YUV420P10),
 #endif
+#ifdef VA_FOURCC_Q416
+    MAP(Q416, YUV444P16),
+#endif
 #undef MAP
 };

diff --git a/libavutil/hwcontext_vaapi.c b/libavutil/hwcontext_vaapi.c
index 938bd5447d..ec70775556 100644
--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -161,6 +161,10 @@ static const VAAPIFormatDescriptor vaapi_format_map[] = {
     // support for Y412, so we must fudge the mapping here.
     MAP(Y412, YUV444_12,  XV36, 0),
 #endif
+#ifdef VA_FOURCC_Q416
+    MAP(Q416, YUV444_10,  YUV444P16, 0),
+    MAP(Q416, YUV444_12,  YUV444P16, 0),
+#endif
 };
 #undef MAP
```

`libva` 2.19.0
```diff
diff --git a/va/va.h b/va/va.h
index 5b98658..bb44539 100644
--- a/va/va.h
+++ b/va/va.h
@@ -4574,6 +4574,11 @@ VAStatus vaSyncBuffer(
  * Four bytes per pixel: X, Y, U, V.
  */
 #define VA_FOURCC_XYUV          0x56555958
+/** Q416: three-plane 16-bit YUV 4:4:4.
+ *
+ * The three planes contain Y, U and V respectively.
+ */
+#define VA_FOURCC_Q416          0x36313451

 /* byte order */
 #define VA_LSB_FIRST        1
```

I will also pull request these patches to [libva](https://github.com/intel/libva) and FFmpeg repo.