### PR TITLE
Fix check method for ffmpeg vaapi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Environment variables used to control the behavior of this library.
 
 ## Firefox
 
-To use the driver with firefox you will need at least Firefox 96, `ffmpeg` compiled with vaapi support (search ffmpeg output for --enable-vaapi), and the following config options need to be set in the `about:config` page:
+To use the driver with firefox you will need at least Firefox 96, `ffmpeg` compiled with vaapi support (`ffmpeg -hwaccels` output should include vaapi), and the following config options need to be set in the `about:config` page:
 
 | Option | Value | Reason |
 |---|---|---|


### PR DESCRIPTION
The switch `--enable-vaapi` does not exist in ffmpeg upstream's configure script. Instead there's a [`--disable-vaapi`](https://github.com/FFmpeg/FFmpeg/blob/d9d56953906103dfae351e4d32af501fa1d62bdb/configure#L354) switch. 

FFmpeg autodetects whether vaapi support should be enabled by default, and the proper way to check for that at runtime is `ffmpeg -hwaccels`.

On my Arch Linux system, with extra/ffmpeg 2:6.0-8:
```
$ ffmpeg -hwaccels 
ffmpeg version n6.0 Copyright (c) 2000-2023 the FFmpeg developers
  built with gcc 13.1.1 (GCC) 20230429
  configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-amf --enable-avisynth --enable-cuda-llvm --enable-lto --enable-fontconfig --enable-gmp --enable-gnutls --enable-gpl --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libdav1d --enable-libdrm --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libiec61883 --enable-libjack --enable-libjxl --enable-libmfx --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librav1e --enable-librsvg --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-libzimg --enable-nvdec --enable-nvenc --enable-opencl --enable-opengl --enable-shared --enable-version3 --enable-vulkan
  libavutil      58.  2.100 / 58.  2.100
  libavcodec     60.  3.100 / 60.  3.100
  libavformat    60.  3.100 / 60.  3.100
  libavdevice    60.  1.100 / 60.  1.100
  libavfilter     9.  3.100 /  9.  3.100
  libswscale      7.  1.100 /  7.  1.100
  libswresample   4. 10.100 /  4. 10.100
  libpostproc    57.  1.100 / 57.  1.100
Hardware acceleration methods:
vdpau
cuda
vaapi
qsv
drm
opencl
vulkan
```
Note how there's no `--enable-vaapi` in the above output.