### PR TITLE
Single buffer export

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,21 @@
+//
+// Created by stephen on 12/11/23.
+//
+
+#ifndef COMMON_H
+#define COMMON_H
+
+typedef struct
+{
+    uint32_t x;
+    uint32_t y;
+} NVSubSampling;
+
+typedef struct
+{
+    uint32_t channelCount;
+    uint32_t fourcc;
+    NVSubSampling ss; // subsampling
+} NVFormatPlane;
+
+#endif //COMMON_H

--- a/src/direct/nv-driver.h
+++ b/src/direct/nv-driver.h
@@ -42,5 +42,7 @@ bool free_nvdriver(NVDriverContext *context);
 bool get_device_uuid(NVDriverContext *context, char uuid[16]);
 bool alloc_memory(NVDriverContext *context, uint32_t size, int *fd);
 bool alloc_image(NVDriverContext *context, uint32_t width, uint32_t height, uint8_t channels, uint8_t bytesPerChannel, uint32_t fourcc, NVDriverImage *image);
+bool alloc_buffer(NVDriverContext *context, uint32_t size, uint32_t widthInBytes, int *fd1, int *fd2, int *drmFd);
+uint32_t calculate_image_size(uint32_t width, uint32_t height, uint8_t channels, uint8_t bitsPerChannel, uint32_t* widthInBytesOut);
 
 #endif

--- a/src/direct/nv-driver.h
+++ b/src/direct/nv-driver.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "../common.h"
 #include "nvidia-drm-ioctl.h"
 
 #define ROUND_UP(N, S) ((((N) + (S) - 1) / (S)) * (S))
@@ -25,9 +26,6 @@ typedef struct {
 } NVDriverContext;
 
 typedef struct {
-    int nvFd;
-    int nvFd2;
-    int drmFd;
     uint32_t width;
     uint32_t height;
     uint64_t mods;
@@ -35,14 +33,15 @@ typedef struct {
     uint32_t offset;
     uint32_t pitch;
     uint32_t fourcc;
+    uint32_t log2GobsPerBlockX;
+    uint32_t log2GobsPerBlockY;
+    uint32_t log2GobsPerBlockZ;
 } NVDriverImage;
 
 bool init_nvdriver(NVDriverContext *context, int drmFd);
 bool free_nvdriver(NVDriverContext *context);
-bool get_device_uuid(NVDriverContext *context, char uuid[16]);
-bool alloc_memory(NVDriverContext *context, uint32_t size, int *fd);
-bool alloc_image(NVDriverContext *context, uint32_t width, uint32_t height, uint8_t channels, uint8_t bytesPerChannel, uint32_t fourcc, NVDriverImage *image);
-bool alloc_buffer(NVDriverContext *context, uint32_t size, uint32_t widthInBytes, int *fd1, int *fd2, int *drmFd);
-uint32_t calculate_image_size(uint32_t width, uint32_t height, uint8_t channels, uint8_t bitsPerChannel, uint32_t* widthInBytesOut);
-
+bool get_device_uuid(const NVDriverContext *context, char uuid[16]);
+bool alloc_memory(const NVDriverContext *context, uint32_t size, int *fd);
+bool alloc_buffer(NVDriverContext *context, uint32_t size, const NVDriverImage images[], int *fd1, int *fd2, int *drmFd);
+uint32_t calculate_image_size(const NVDriverContext *context, NVDriverImage images[], uint32_t width, uint32_t height, uint32_t bppc, uint32_t numPlanes, const NVFormatPlane planes[]);
 #endif

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -2039,7 +2039,7 @@ static VAStatus nvExportSurfaceHandle(
 
     drv->backend->fillExportDescriptor(drv, surface, ptr);
 
-    LOG("Exporting with %d %d %d %d %" PRIx64 " %d %d %" PRIx64, ptr->width, ptr->height, ptr->layers[0].offset[0],
+    LOG("Exporting with w:%d h:%d o:%d p:%d m:%" PRIx64 " o:%d p:%d m:%" PRIx64, ptr->width, ptr->height, ptr->layers[0].offset[0],
                                                                  ptr->layers[0].pitch[0], ptr->objects[0].drm_format_modifier,
                                                                  ptr->layers[1].offset[0], ptr->layers[1].pitch[0],
                                                                  ptr->objects[1].drm_format_modifier);

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -11,6 +11,7 @@
 #include <pthread.h>
 #include "list.h"
 #include "direct/nv-driver.h"
+#include "common.h"
 
 #define SURFACE_QUEUE_SIZE 16
 #define MAX_IMAGE_COUNT 64
@@ -204,19 +205,6 @@ struct _NVCodec {
 };
 
 typedef struct _NVCodec NVCodec;
-
-typedef struct
-{
-    uint32_t x;
-    uint32_t y;
-} NVSubSampling;
-
-typedef struct
-{
-    uint32_t channelCount;
-    uint32_t fourcc;
-    NVSubSampling ss; // subsampling
-} NVFormatPlane;
 
 typedef struct
 {

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -107,6 +107,8 @@ typedef struct _BackingImage {
     //direct backend only
     NVCudaImage cudaImages[3];
     NVFormat    format;
+    uint32_t    totalSize;
+    CUexternalMemory extMem;
 } BackingImage;
 
 struct _NVDriver;


### PR DESCRIPTION
Rather than exporting two buffers, this patch allows the driver to export just one, which in theory allows us to be compatible with Chrome which only supports importing one buffer.