### PR TITLE
Fix undefined reference to 'gettid' on CentOS 8

### DIFF
--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -41,7 +41,6 @@
 
 #ifndef HAVE_GETTID
 #include <sys/syscall.h>
-#include <unistd.h>
 /* Bionic and glibc >= 2.30 declare gettid() system call wrapper in unistd.h and
  * has a definition for it */
 #ifdef __BIONIC__

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -36,7 +36,33 @@
 #if __has_include(<pthread_np.h>)
 #include <pthread_np.h>
 #define gettid pthread_getthreadid_np
+#define HAVE_GETTID 1
 #endif
+
+#ifndef HAVE_GETTID
+#include <sys/syscall.h>
+#include <unistd.h>
+/* Bionic and glibc >= 2.30 declare gettid() system call wrapper in unistd.h and
+ * has a definition for it */
+#ifdef __BIONIC__
+#define HAVE_GETTID 1
+#elif !defined(__GLIBC_PREREQ)
+#define HAVE_GETTID 0
+#elif !__GLIBC_PREREQ(2,30)
+#define HAVE_GETTID 0
+#else
+#define HAVE_GETTID 1
+#endif
+#endif
+
+static pid_t nv_gettid(void)
+{
+#if HAVE_GETTID
+    return gettid();
+#else
+    return syscall(__NR_gettid);
+#endif
+}
 
 static pthread_mutex_t concurrency_mutex = PTHREAD_MUTEX_INITIALIZER;
 static uint32_t instances;
@@ -176,7 +202,7 @@ void logger(const char *filename, const char *function, int line, const char *ms
     struct timespec tp;
     clock_gettime(CLOCK_MONOTONIC, &tp);
 
-    fprintf(LOG_OUTPUT, "%10ld.%09ld [%d-%d] %s:%4d %24s %s\n", (long)tp.tv_sec, tp.tv_nsec, getpid(), gettid(), filename, line, function, formattedMessage);
+    fprintf(LOG_OUTPUT, "%10ld.%09ld [%d-%d] %s:%4d %24s %s\n", (long)tp.tv_sec, tp.tv_nsec, getpid(), nv_gettid(), filename, line, function, formattedMessage);
     fflush(LOG_OUTPUT);
 }
 

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -13,6 +13,13 @@
 #include "direct/nv-driver.h"
 #include "common.h"
 
+#include <unistd.h>
+#include <sys/syscall.h>
+#ifndef SYS_gettid
+#error "SYS_gettid unavailable on this system"
+#endif
+#define gettid() ((pid_t)syscall(SYS_gettid))
+
 #define SURFACE_QUEUE_SIZE 16
 #define MAX_IMAGE_COUNT 64
 

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -13,13 +13,6 @@
 #include "direct/nv-driver.h"
 #include "common.h"
 
-#include <unistd.h>
-#include <sys/syscall.h>
-#ifndef SYS_gettid
-#error "SYS_gettid unavailable on this system"
-#endif
-#define gettid() ((pid_t)syscall(SYS_gettid))
-
 #define SURFACE_QUEUE_SIZE 16
 #define MAX_IMAGE_COUNT 64
 


### PR DESCRIPTION
The link error is:
```
../src/vabackend.c: In function ‘logger’:
../src/vabackend.c:166:98: warning: implicit declaration of function ‘gettid’; did you mean ‘getgid’? [-Wimplicit-function-declaration]
     fprintf(LOG_OUTPUT, "%10ld.%09ld [%d-%d] %s:%4d %24s %s\n", tp.tv_sec, tp.tv_nsec, getpid(), gettid(), filename, line, function, formattedMessage);
                                                                                                  ^~~~~~
                                                                                                  getgid
...
nvidia_drv_video.so.p/src_vabackend.c.o: In function `logger':
/root/rpmbuild/BUILD/nvidia-vaapi-driver-0.0.11/x86_64-redhat-linux-gnu/../src/vabackend.c:166: undefined reference to `gettid'
collect2: error: ld returned 1 exit status
```
With this patch it compiles and works correctly on CentOS 8.