### PR TITLE
vabackend: Treat surfaceCount == 1 the same as surfaceCount == 0

### DIFF
--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -1043,12 +1043,12 @@ static VAStatus nvCreateContext(
         cfg->bitDepth = surface->bitDepth;
     }
 
-    if (drv->surfaceCount == 0 && num_render_targets == 0) {
-        LOG("0 surfaces have been passed to vaCreateContext, this might cause errors. Setting surface count to 32");
+    if (drv->surfaceCount <= 1 && num_render_targets == 0) {
+        LOG("0/1 surfaces have been passed to vaCreateContext, this might cause errors. Setting surface count to 32");
         num_render_targets = 32;
     }
 
-    int surfaceCount = drv->surfaceCount != 0 ? drv->surfaceCount : num_render_targets;
+    int surfaceCount = drv->surfaceCount > 1 ? drv->surfaceCount : num_render_targets;
     if (surfaceCount > 32) {
         LOG("Application requested %d surface(s), limiting to 32. This may cause issues.", surfaceCount);
         surfaceCount = 32;


### PR DESCRIPTION
When Chrome(ium) wants dynamic surface allocation it starts with an initial count of 0, and that is handled today. On the other hand, recent versions of ffmpeg have switched to preferring dynamic allocation but they start with a surfaceCount of 1. If we treat this as a legitimate static request, we cannot do any decoding in practice, as you always need more than 1 surface.

So, treat a surfaceCount of 1 the same as 0, and use our same dynamic allocation work-around.

Fixes #292 