### PR TITLE
fix: detect correct DRM driver on wayland

### DIFF
--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -2186,13 +2186,9 @@ __attribute__((visibility("default")))
 VAStatus __vaDriverInit_1_0(VADriverContextP ctx) {
     LOG("Initialising NVIDIA VA-API Driver: %lX", ctx->display_type);
 
-    //drm_state can be passed in with any display type, including X11. But if it's X11, we don't
-    //want to use the fd as it'll likely be an Intel GPU, as NVIDIA doesn't support DRI3 at the moment
-    // bool isDrm = ctx->drm_state != NULL && ((struct drm_state*) ctx->drm_state)->fd > 0 &&
-    //              (((ctx->display_type & VA_DISPLAY_MAJOR_MASK) == VA_DISPLAY_DRM) ||
-    //               ((ctx->display_type & VA_DISPLAY_MAJOR_MASK) == VA_DISPLAY_WAYLAND));
-
-    // fix: ignore fd on wayland as well
+    //drm_state can be passed in with any display type, including X11. But if it's X11 or wayland, we 
+    //don't want to use the fd as it'll likely be an Intel GPU, as NVIDIA doesn't support DRI3 at the
+    //moment
     bool isDrm = ctx->drm_state != NULL && ((struct drm_state*) ctx->drm_state)->fd > 0 &&
                  ((ctx->display_type & VA_DISPLAY_MAJOR_MASK) == VA_DISPLAY_DRM);   
 

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -2188,9 +2188,13 @@ VAStatus __vaDriverInit_1_0(VADriverContextP ctx) {
 
     //drm_state can be passed in with any display type, including X11. But if it's X11, we don't
     //want to use the fd as it'll likely be an Intel GPU, as NVIDIA doesn't support DRI3 at the moment
+    // bool isDrm = ctx->drm_state != NULL && ((struct drm_state*) ctx->drm_state)->fd > 0 &&
+    //              (((ctx->display_type & VA_DISPLAY_MAJOR_MASK) == VA_DISPLAY_DRM) ||
+    //               ((ctx->display_type & VA_DISPLAY_MAJOR_MASK) == VA_DISPLAY_WAYLAND));
+
+    // fix: ignore fd on wayland as well
     bool isDrm = ctx->drm_state != NULL && ((struct drm_state*) ctx->drm_state)->fd > 0 &&
-                 (((ctx->display_type & VA_DISPLAY_MAJOR_MASK) == VA_DISPLAY_DRM) ||
-                  ((ctx->display_type & VA_DISPLAY_MAJOR_MASK) == VA_DISPLAY_WAYLAND));
+                 ((ctx->display_type & VA_DISPLAY_MAJOR_MASK) == VA_DISPLAY_DRM);   
 
     pthread_mutex_lock(&concurrency_mutex);
     LOG("Now have %d (%d max) instances", instances, max_instances);


### PR DESCRIPTION
Closes https://github.com/elFarto/nvidia-vaapi-driver/issues/330

After upgrading to linux kernel 6.11 and nvidia drivers 560, vaapi wouldn't use the right DRM drivers when on wayland. This PR fixes it by forcing it to search for the right DRM driver when on wayland, much like it was previously set to force it on x11.

As a disclaimer, I will admit that I'm not 100% sure if this is a "necessary" fix, or if it's just a band-aid patch to a misconfigured system on my side (Further testing is needed). However, it does fix my issue, and vainfo launches successfully on wayland. If it ends up that there's a better way to address the issue, feel free to close this PR.