### PR TITLE
Reverted single plane export

### DIFF
--- a/src/direct/nv-driver.h
+++ b/src/direct/nv-driver.h
@@ -26,6 +26,9 @@ typedef struct {
 } NVDriverContext;
 
 typedef struct {
+    int nvFd;
+    int nvFd2;
+    int drmFd;
     uint32_t width;
     uint32_t height;
     uint64_t mods;
@@ -33,15 +36,12 @@ typedef struct {
     uint32_t offset;
     uint32_t pitch;
     uint32_t fourcc;
-    uint32_t log2GobsPerBlockX;
-    uint32_t log2GobsPerBlockY;
-    uint32_t log2GobsPerBlockZ;
 } NVDriverImage;
 
 bool init_nvdriver(NVDriverContext *context, int drmFd);
 bool free_nvdriver(NVDriverContext *context);
 bool get_device_uuid(const NVDriverContext *context, uint8_t uuid[16]);
 bool alloc_memory(const NVDriverContext *context, uint32_t size, int *fd);
-bool alloc_buffer(NVDriverContext *context, uint32_t size, const NVDriverImage images[], int *fd1, int *fd2, int *drmFd);
-uint32_t calculate_image_size(const NVDriverContext *context, NVDriverImage images[], uint32_t width, uint32_t height, uint32_t bppc, uint32_t numPlanes, const NVFormatPlane planes[]);
+bool alloc_image(NVDriverContext *context, uint32_t width, uint32_t height, uint8_t channels, uint8_t bytesPerChannel, uint32_t fourcc, NVDriverImage *image);
+
 #endif


### PR DESCRIPTION
Single plane export wasn't a good idea as the export format modifier can be different between the Y and UV planes, causing visual artefacts. As Chrome seems to support multi plane import now, this wasn't needed.