### PR TITLE
Fix some potential deadlocks and H.264 video decode error when seeking

### DIFF
--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -67,6 +67,7 @@ typedef struct
     int                     resolving;
     pthread_mutex_t         mutex;
     pthread_cond_t          cond;
+    bool                    decodeFailed;
 } NVSurface;
 
 typedef enum

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -179,6 +179,7 @@ typedef struct _NVContext
     int                 surfaceQueueWriteIdx;
     bool                exiting;
     pthread_mutex_t     surfaceCreationMutex;
+    int                 surfaceCount;
 } NVContext;
 
 typedef struct


### PR DESCRIPTION
This commit fixes 2 possible deadlocks:
* When a decode error occurs, the surface condition should be signaled otherwise decoding will hang as in https://github.com/elFarto/nvidia-vaapi-driver/issues/343
* `deleteAllObjects` should delete all objects not only context objects. I also removed `deleteObject` because it also calls `pthread_mutex_lock(&drv->objectCreationMutex);`, so it will cause a deadlock.