### PR TITLE
Fixed crashes caused by invalid concurrent writes to `drv->nextObjId`

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -24,7 +24,7 @@ static void ensure_capacity(Array *arr, uint32_t new_capacity) {
     arr->buf = realloc(arr->buf, arr->capacity * sizeof(void*));
 
     //clear the new part of the array
-    memset(&arr->buf[old_capacity], 0, (arr->capacity - old_capacity) * sizeof(void*));
+    memset(&arr->buf[old_capacity], 0, (size_t)(arr->capacity - old_capacity) * sizeof(void*));
 }
 
 void add_element(Array *arr, void *element) {

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -41,10 +41,10 @@ typedef struct Object_t
 typedef struct
 {
     unsigned int    elements;
-    int             size;
+    size_t          size;
     VABufferType    bufferType;
     void            *ptr;
-    int             offset;
+    size_t          offset;
 } NVBuffer;
 
 struct _NVContext;
@@ -83,8 +83,8 @@ typedef enum
 
 typedef struct
 {
-    int         width;
-    int         height;
+    uint32_t    width;
+    uint32_t    height;
     NVFormat    format;
     NVBuffer    *imageBuffer;
 } NVImage;
@@ -137,7 +137,6 @@ typedef struct _NVDriver
     bool                    supports444Surface;
     int                     cudaGpuId;
     int                     drmFd;
-    int                     surfaceCount;
     pthread_mutex_t         exportMutex;
     pthread_mutex_t         imagesMutex;
     Array/*<NVEGLImage>*/   images;
@@ -160,8 +159,8 @@ typedef struct _NVContext
     NVDriver            *drv;
     VAProfile           profile;
     VAEntrypoint        entrypoint;
-    int                 width;
-    int                 height;
+    uint32_t            width;
+    uint32_t            height;
     CUvideodecoder      decoder;
     NVSurface           *renderTarget;
     void                *lastSliceParams;


### PR DESCRIPTION
I restored the old behavior in `nvCreateContext` with `num_render_targets` and I implemented `reconfigureDecoderSurfaceCount` to reconfigure decoder if the application create surfaces after context creation.
I also rounded up memory size to 4096 in `alloc_image` as allocation seems to fail in `mpv` with the 570.133.07 driver:
`[drm:__nv_drm_nvkms_gem_obj_init [nvidia_drm]] *ERROR* [nvidia-drm] [GPU ID 0x00002d00] NvKmsKapiMemory 0x00000000e087270f size should be in a multiple of page size to create a gem object`