### PR TITLE
Add media.hardware-video-decoding.force-enabled FF option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ To use the driver with firefox you will need at least Firefox 96, `ffmpeg` compi
 
 | Option | Value | Reason |
 |---|---|---|
-| media.ffmpeg.vaapi.enabled | true | Required, enables the use of VA-API. |
+| media.ffmpeg.vaapi.enabled | true | Required until Firefox 137, enables the use of VA-API. |
+| media.hardware-video-decoding.force-enabled | true | Required since Firefox 137, enables hardware acceleration. |
 | media.rdd-ffmpeg.enabled | true | Required, default on FF97. Forces ffmpeg usage into the RDD process, rather than the content process. |
 | media.av1.enabled | false | Optional, disables AV1. If your GPU doesn't support AV1, this will prevent sites using it and falling back to software decoding. |
 | gfx.x11-egl.force-enabled | true | Required, this driver requires that Firefox use the EGL backend. It may be enabled by default. It is recommended to test it with the `MOZ_X11_EGL=1` environment variable before enabling it in the Firefox configuration. |


### PR DESCRIPTION
Added a new media.hardware-video-decoding.force-enabled option that is required since Firefox 137 and note that media.ffmpeg.vaapi.enabled is no longer needed.

As noted in https://github.com/elFarto/nvidia-vaapi-driver/issues/358#issuecomment-2769502201.