### PR TITLE
Fix 32-bit issues

### DIFF
--- a/src/direct/nv-driver.c
+++ b/src/direct/nv-driver.c
@@ -35,8 +35,8 @@ static bool nv_alloc_object(const int fd, const uint32_t driverMajorVersion, con
         .hObjectParent = hObjectParent,
         .hObjectNew = *hObjectNew,
         .hClass = hClass,
-        .pRightsRequested = (NvP64)NULL,
-        .pAllocParms = (NvP64)params,
+        .pRightsRequested = (NvP64)(uintptr_t)NULL,
+        .pAllocParms = (NvP64)(uintptr_t)params,
         .paramsSize = paramSize
     };
 
@@ -105,7 +105,7 @@ static bool nv_rm_control(const int fd, const NvHandle hClient, const NvHandle h
         .hObject = hObject,
         .cmd = cmd,
         .flags = flags,
-        .params = (NvP64)params,
+        .params = (NvP64)(uintptr_t)params,
         .paramsSize = paramSize
     };
 
@@ -552,7 +552,7 @@ bool alloc_memory(const NVDriverContext *context, const uint32_t size, int *fd) 
 
      struct drm_nvidia_gem_import_nvkms_memory_params params = {
          .mem_size = imageSizeInBytes,
-         .nvkms_params_ptr = (uint64_t) &nvkmsParams,
+         .nvkms_params_ptr = (uint64_t)(uintptr_t)&nvkmsParams,
          .nvkms_params_size = context->driverMajorVersion == 470 ? 0x20 : sizeof(nvkmsParams) //needs to be 0x20 in the 470 series driver
      };
      int drmret = ioctl(context->drmFd, DRM_IOCTL_NVIDIA_GEM_IMPORT_NVKMS_MEMORY, &params);

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -1204,7 +1204,7 @@ static VAStatus nvCreateBuffer(
     buf->offset = offset;
 
     if (buf->ptr == NULL) {
-        LOG("Unable to allocate buffer of %lu bytes", buf->size);
+        LOG("Unable to allocate buffer of %zu bytes", buf->size);
         return VA_STATUS_ERROR_ALLOCATION_FAILED;
     }
 


### PR DESCRIPTION
This fixes compilation error on i386 (and possibly other 32-bit targets) due to incorrect `printf` format specifier for a `size_t` value.

It also resolves gcc warnings caused by casing pointers directly to 64-bit integers. The result of such casts is not defined if the most significant bit of the pointer representation is set (i.e. the resulting integer may get sign-extended or zero-extended).
    
Use `uintptr_t` for the intermediate cast to unsigned integer which is then converted to the resulting 64-bit integer (by zero-extending).
