### PR TITLE
Fix "possibly uninitialized" warning

### DIFF
--- a/src/export-buf.c
+++ b/src/export-buf.c
@@ -120,7 +120,7 @@ static bool reconnect(NVDriver *drv) {
 
 static void findGPUIndexFromFd(NVDriver *drv) {
     struct stat buf;
-    int drmDeviceIndex;
+    int drmDeviceIndex = 0;
     PFNEGLQUERYDEVICESEXTPROC eglQueryDevicesEXT = (PFNEGLQUERYDEVICESEXTPROC) eglGetProcAddress("eglQueryDevicesEXT");
     PFNEGLQUERYDEVICEATTRIBEXTPROC eglQueryDeviceAttribEXT = (PFNEGLQUERYDEVICEATTRIBEXTPROC) eglGetProcAddress("eglQueryDeviceAttribEXT");
     PFNEGLQUERYDEVICESTRINGEXTPROC eglQueryDeviceStringEXT = (PFNEGLQUERYDEVICESTRINGEXTPROC) eglGetProcAddress("eglQueryDeviceStringEXT");


### PR DESCRIPTION
This fixes gcc 13 warning about `drmDeviceIndex` possibly being uninitialized when used. The warning is probably bogus, but easy to silence.