### PR TITLE
Skip Firefox check on FreeBSD

### DIFF
--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -133,6 +133,7 @@ static void init() {
         }
     }
 
+#ifdef __linux__
     //try to detect the Firefox sandbox and skip loading CUDA if detected
     int fd = open("/proc/version", O_RDONLY);
     if (fd < 0) {
@@ -147,6 +148,7 @@ static void init() {
         //continue as normal
         close(fd);
     }
+#endif
 
     //initialise the CUDA and NVDEC functions
     int ret = cuda_load_functions(&cu, NULL);


### PR DESCRIPTION
Follow up to #220. Disable b1cc9028d9fd to avoid requiring `NVD_FORCE_INIT=1`. Found via `grep -r /proc`.

In FreeBSD case:
- Firefox sandboxing is [not supported yet](https://bugzilla.mozilla.org/show_bug.cgi?id=1607980)
- `/proc` is deprecated (unmounted by default) and doesn't contain `version` file ([procfs(5)](https://man.freebsd.org/procfs/5) vs. [linprocfs(5)](https://man.freebsd.org/linprocfs/5))
