### PR TITLE
Vp8 fix

### DIFF
--- a/src/vp8.c
+++ b/src/vp8.c
@@ -48,6 +48,14 @@ static void copyVP8SliceData(NVContext *ctx, NVBuffer* buf, CUVIDPICPARAMS *picP
     }
 }
 
+static void ignoreVP8Buffer(NVContext *ctx, NVBuffer *buffer, CUVIDPICPARAMS *picParams)
+{
+    // Intentionally do nothing
+    (void)ctx;
+    (void)buffer;
+    (void)picParams;
+}
+
 static cudaVideoCodec computeVP8CudaCodec(VAProfile profile) {
     if (profile == VAProfileVP8Version0_3) {
         return cudaVideoCodec_VP8;
@@ -66,6 +74,8 @@ const DECLARE_CODEC(vp8Codec) = {
         [VAPictureParameterBufferType] = copyVP8PicParam,
         [VASliceParameterBufferType] = copyVP8SliceParam,
         [VASliceDataBufferType] = copyVP8SliceData,
+        [VAIQMatrixBufferType]         = ignoreVP8Buffer,
+        [VAProbabilityBufferType]      = ignoreVP8Buffer,
     },
     .supportedProfileCount = ARRAY_SIZE(vp8SupportedProfiles),
     .supportedProfiles = vp8SupportedProfiles,


### PR DESCRIPTION
VA-API doesn't pass the slice header, but NVDEC ingests it, despite the hardware block not needing it. Adding 10/3 null bytes as the header for i-frames/other frames gives CUVID the expected offsets for video data, fixing the green "corruption" seen in VP8 video.

Additionally, buffertypes 1 and 13 (VAIQMatrixBuffer and VAProbabilityBuffer) are no-op'd as CUVID does not make use of similar buffer types and no-oping them reduces logspam.

Vesktop GIF picker
<img width="509" height="495" alt="image" src="https://github.com/user-attachments/assets/eb2cf090-6a28-43c3-a3d0-6c28be11a94c" />

Insurgency trailer on Chromium
<img width="2560" height="1396" alt="image" src="https://github.com/user-attachments/assets/42b20f39-1f0d-4422-bd3e-268232330cf0" />

closes #386 