### PR TITLE
Accumulate all SliceParams calls before SliceData

### DIFF
--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -330,6 +330,7 @@ static bool destroyContext(NVDriver *drv, NVContext *nvCtx) {
     int ret = pthread_timedjoin_np(nvCtx->resolveThread, NULL, &timeout);
     LOG("Finished waiting for resolve thread with %d", ret);
 
+    freeBuffer(&nvCtx->sliceParams);
     freeBuffer(&nvCtx->sliceOffsets);
     freeBuffer(&nvCtx->bitstreamBuffer);
 

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -167,8 +167,8 @@ typedef struct _NVContext
     uint32_t            height;
     CUvideodecoder      decoder;
     NVSurface           *renderTarget;
-    void                *lastSliceParams;
-    unsigned int        lastSliceParamsCount;
+    AppendableBuffer    sliceParams;
+    unsigned int        sliceParamsCount;
     AppendableBuffer    bitstreamBuffer;
     AppendableBuffer    sliceOffsets;
     CUVIDPICPARAMS      pPicParams;


### PR DESCRIPTION
Chromium expects this, and since it works with other drivers, it must be allowed.

Fixes #405