### PR TITLE
Workaround for clients like Chromium for AV1, misc fixes

### DIFF
--- a/src/av1.c
+++ b/src/av1.c
@@ -258,14 +258,13 @@ static void copyAV1PicParam(NVContext *ctx, NVBuffer* buffer, CUVIDPICPARAMS *pi
         int ref_idx = buf->ref_frame_idx[i];
         pps->ref_frame[i].index = pps->ref_frame_map[ref_idx];
         //pull these from the surface itself
-        NVSurface *surf = nvSurfaceFromSurfaceId(ctx->drv, buf->ref_frame_map[i]);
+        NVSurface *surf = nvSurfaceFromSurfaceId(ctx->drv, buf->ref_frame_map[ref_idx]);
         if (surf != NULL) {
             pps->ref_frame[i].width = surf->width;
             pps->ref_frame[i].height = surf->height;
         }
 
-        //TODO not sure on this one
-        pps->global_motion[i].invalid = (buf->wm[i].wmtype == 0);
+        pps->global_motion[i].invalid = buf->wm[i].invalid;
         pps->global_motion[i].wmtype = buf->wm[i].wmtype;
         for (int j = 0; j < 6; j++) {
             pps->global_motion[i].wmmat[j] = buf->wm[i].wmmat[j];

--- a/src/av1.c
+++ b/src/av1.c
@@ -82,7 +82,6 @@ static void copyAV1PicParam(NVContext *ctx, NVBuffer* buffer, CUVIDPICPARAMS *pi
     pps->num_tile_cols = buf->tile_cols;
     pps->num_tile_rows = buf->tile_rows;
     pps->context_update_tile_id = buf->context_update_tile_id;
-    picParams->nNumSlices = pps->num_tile_cols * pps->num_tile_rows;
 
     pps->cdef_damping_minus_3 = buf->cdef_damping_minus_3;
     pps->cdef_bits = buf->cdef_bits;

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -1343,6 +1343,10 @@ static VAStatus nvBeginPicture(
     nvCtx->renderTarget->progressiveFrame = true; //assume we're producing progressive frame unless the codec says otherwise
     nvCtx->pPicParams.CurrPicIdx = nvCtx->renderTarget->pictureIdx;
 
+    nvCtx->bitstreamBuffer.size = 0;
+    nvCtx->sliceOffsets.size = 0;
+    nvCtx->lastSliceDataOffset = 0;
+
     return VA_STATUS_SUCCESS;
 }
 
@@ -1397,6 +1401,7 @@ static VAStatus nvEndPicture(
     picParams->pSliceDataOffsets = nvCtx->sliceOffsets.buf;
     nvCtx->bitstreamBuffer.size = 0;
     nvCtx->sliceOffsets.size = 0;
+    nvCtx->lastSliceDataOffset = 0;
 
     CHECK_CUDA_RESULT_RETURN(cu->cuCtxPushCurrent(drv->cudaContext), VA_STATUS_ERROR_OPERATION_FAILED);
     CUresult result = cv->cuvidDecodePicture(nvCtx->decoder, picParams);

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -169,6 +169,7 @@ typedef struct _NVContext
     NVSurface           *renderTarget;
     void                *lastSliceParams;
     unsigned int        lastSliceParamsCount;
+    uint32_t            lastSliceDataOffset;
     AppendableBuffer    bitstreamBuffer;
     AppendableBuffer    sliceOffsets;
     CUVIDPICPARAMS      pPicParams;


### PR DESCRIPTION
Clients like Chromium and company will send a single slice data buffer, followed by multiple slice params buffers. Work around this by handling both possible cases, including sending multiple series of params/data interleaved.

Intended to fix #405

This doesn't seem to work fully, so there's probably something else broken. It works with Firefox still, so at least I didn't break it.

Note that this handling behavior and offsets per data slice is what Mesa/Gallium does to accommodate similarly designed clients.