### PR TITLE
Fix nvGetConfigAttributes by adding a missing check for entrypoint

### DIFF
--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -618,6 +618,10 @@ static VAStatus nvGetConfigAttributes(
         int num_attribs
     )
 {
+    if (entrypoint != VAEntrypointVLD) {
+        return VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT;
+    }
+
     NVDriver *drv = (NVDriver*) ctx->pDriverData;
     if (vaToCuCodec(profile) == cudaVideoCodec_NONE) {
         return VA_STATUS_ERROR_UNSUPPORTED_PROFILE;


### PR DESCRIPTION
`nvGetConfigAttributes` currently doesn't check whether a valid entrypoint was provided.
This breaks KPipeWire and therefore, screen recording using Spectacle on Wayland.

This is because KPipeWire checks for encoding support just by calling `getConfigAttributes` with a corresponding entrypoint and checking the result. Since we didn't check the entrypoint before, we returned *encoding* support for all supported decoding formats, making KPipeWire try using this driver for encoding (and, unexpectedly, failing to do so, resulting in broken recording).

This PR fixes this issue by adding a very simple if statement at the beginning of the function, immediately returning an error if the supplied entrypoint is wrong.