### PR TITLE
direct: export multi-plane YUV as one dma-buf object per plane

### DIFF
--- a/src/direct/direct-export-buf.c
+++ b/src/direct/direct-export-buf.c
@@ -613,7 +613,7 @@ static BackingImage *direct_allocateBackingImage(NVDriver *drv, NVSurface *surfa
         // per-plane importers (mpv/GStreamer/ffmpeg), which import each layer as a
         // standalone dma-buf and can't handle a tiled plane starting at a byte offset. The
         // single-buffer layout is kept behind NVD_SINGLE_BUFFER for comparison/fallback.
-        if (getenv("NVD_SINGLE_BUFFER") != NULL) {
+        if (nvdSingleBufferForced()) {
             return direct_allocateBackingImage_single(drv, surface);
         }
         return direct_allocateBackingImage_perPlane(drv, surface);

--- a/src/direct/direct-export-buf.c
+++ b/src/direct/direct-export-buf.c
@@ -386,6 +386,106 @@ static void pruneDetachedBackingImagesToLimits(NVDriver *drv) {
     pthread_mutex_unlock(&drv->imagesMutex);
 }
 
+// Allocate a multi-plane YUV backing image as one dma-buf object per plane, all sharing a
+// single (max-across-planes) block-linear modifier. This satisfies Chromium's requirement
+// that every plane report the same DRM modifier while keeping each plane at offset 0 of its
+// own object, so per-plane importers (mpv/GStreamer/ffmpeg) detile the chroma plane
+// correctly -- unlike the single-buffer layout, where chroma sits at a non-zero offset
+// inside a shared tiled buffer and those importers mis-detile it.
+static BackingImage *direct_allocateBackingImage_perPlane(NVDriver *drv, NVSurface *surface) {
+    NVDriverImage driverImages[3] = { 0 };
+    BackingImage *backingImage = calloc(1, sizeof(BackingImage));
+    if (backingImage == NULL) {
+        return NULL;
+    }
+    initBackingImageSync(backingImage);
+
+    // Separate object per plane -> the multi-object export/destroy paths handle it.
+    backingImage->isSingleBuffer = false;
+    for (int i = 0; i < 4; i++) {
+        backingImage->fds[i] = -1;
+    }
+
+    backingImage->format = nvFormatForSurface(surface);
+    const NVFormatInfo *fmtInfo = &formatsInfo[backingImage->format];
+
+    // Reuse the unified layout purely to obtain the shared block height and each plane's
+    // pitch/aligned size; the packed offsets it returns are ignored (each plane is offset 0
+    // in its own buffer).
+    calculate_unified_image_layout(&drv->driverContext, driverImages, surface->width, surface->height,
+                                   fmtInfo->bppc, fmtInfo->numPlanes, fmtInfo->plane);
+    LOG_DEBUG("Allocating per-plane BackingImage: %p %ux%u", backingImage, surface->width, surface->height);
+
+    for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
+        int memFd = -1, memFd2 = -1, drmFd = -1;
+        if (!alloc_buffer(&drv->driverContext, driverImages[i].memorySize, &driverImages[i], &memFd, &memFd2, &drmFd)) {
+            goto fail;
+        }
+
+        const CUDA_EXTERNAL_MEMORY_HANDLE_DESC extMemDesc = {
+            .type      = CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD,
+            .handle.fd = memFd,
+            .flags     = 0,
+            .size      = driverImages[i].memorySize
+        };
+        if (CHECK_CUDA_RESULT(drv->cu->cuImportExternalMemory(&backingImage->cudaImages[i].extMem, &extMemDesc))) {
+            close(memFd);
+            close(memFd2);
+            close(drmFd);
+            goto fail;
+        }
+        // memFd is now owned by CUDA; memFd2 must be closed here (see import_to_cuda).
+        close(memFd2);
+        backingImage->fds[i] = drmFd;
+        cacheBackingImageFdStat(backingImage, (int) i);
+
+        // Create the array at the block-aligned height (memorySize / pitch) so CUDA tiles
+        // the plane with the same block height the shared modifier advertises; otherwise a
+        // shorter plane (e.g. NV12 chroma below ~170px coded height, whose natural block is
+        // smaller than luma's) is tiled with a smaller block and the importer detiles it
+        // wrong -> green chroma.
+        const uint32_t alignedHeight = driverImages[i].pitch != 0 ?
+            driverImages[i].memorySize / driverImages[i].pitch : driverImages[i].height;
+        CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC mipmapArrayDesc = {
+            .arrayDesc = {
+                .Width = driverImages[i].width,
+                .Height = alignedHeight,
+                .Depth = 0,
+                .Format = fmtInfo->bppc == 1 ? CU_AD_FORMAT_UNSIGNED_INT8 : CU_AD_FORMAT_UNSIGNED_INT16,
+                .NumChannels = fmtInfo->plane[i].channelCount,
+                .Flags = 0
+            },
+            .numLevels = 1,
+            .offset = 0
+        };
+        if (CHECK_CUDA_RESULT(drv->cu->cuExternalMemoryGetMappedMipmappedArray(&backingImage->cudaImages[i].mipmapArray, backingImage->cudaImages[i].extMem, &mipmapArrayDesc))) {
+            goto fail;
+        }
+        if (CHECK_CUDA_RESULT(drv->cu->cuMipmappedArrayGetLevel(&backingImage->arrays[i], backingImage->cudaImages[i].mipmapArray, 0))) {
+            goto fail;
+        }
+
+        backingImage->strides[i] = driverImages[i].pitch;
+        backingImage->mods[i] = driverImages[i].mods;
+        backingImage->offsets[i] = 0;
+        backingImage->size[i] = driverImages[i].memorySize;
+    }
+
+    backingImage->width = surface->width;
+    backingImage->height = surface->height;
+    backingImage->fourcc = fmtInfo->fourcc;
+
+    if (!clearBackingImage(drv, backingImage)) {
+        goto fail;
+    }
+
+    return backingImage;
+
+fail:
+    destroyBackingImage(drv, backingImage);
+    return NULL;
+}
+
 static BackingImage *direct_allocateBackingImage_single(NVDriver *drv, NVSurface *surface) {
     NVDriverImage driverImages[3] = { 0 };
     BackingImage *backingImage = calloc(1, sizeof(BackingImage));
@@ -506,7 +606,17 @@ static BackingImage *direct_allocateBackingImage(NVDriver *drv, NVSurface *surfa
     // Single-plane / packed surfaces (e.g. RGB) have nothing to unify and use the
     // straightforward per-plane allocator below.
     if (!isRgbSurfaceFourcc((uint32_t) surface->fourcc)) {
-        return direct_allocateBackingImage_single(drv, surface);
+        // Multi-plane YUV: give every plane one shared block-linear modifier (required by
+        // Chromium's one-modifier-per-buffer rule) but put each plane in its OWN dma-buf
+        // object at offset 0. Packing the planes into a single buffer (chroma at a non-zero
+        // offset) is imported fine by Chromium's multi-plane path but mis-detiled by
+        // per-plane importers (mpv/GStreamer/ffmpeg), which import each layer as a
+        // standalone dma-buf and can't handle a tiled plane starting at a byte offset. The
+        // single-buffer layout is kept behind NVD_SINGLE_BUFFER for comparison/fallback.
+        if (getenv("NVD_SINGLE_BUFFER") != NULL) {
+            return direct_allocateBackingImage_single(drv, surface);
+        }
+        return direct_allocateBackingImage_perPlane(drv, surface);
     }
 
     NVDriverImage driverImages[3] = { 0 };

--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -83,6 +83,7 @@ extern const NVCodec __stop_nvd_codecs[];
 static FILE *LOG_OUTPUT;
 static FILE *STATS_OUTPUT;
 static bool LOG_DEBUG_ENABLED;
+static bool SINGLE_BUFFER_FORCED;
 
 // Destination for the statistics dump: the dedicated stats log if one was opened
 // (NVD_STATS_LOG), otherwise the regular log stream. Used by the stats subsystem.
@@ -223,6 +224,9 @@ static void init() {
     }
     char *nvdLogVerbose = getenv("NVD_LOG_VERBOSE");
     LOG_DEBUG_ENABLED = nvdLogVerbose != NULL && strcmp(nvdLogVerbose, "0") != 0;
+    // Global toggle read once here (like every other NVD_* env) instead of via a
+    // getenv on each surface allocation in the direct backend.
+    SINGLE_BUFFER_FORCED = getenv("NVD_SINGLE_BUFFER") != NULL;
     char *nvdStats = getenv("NVD_STATS");
     if (nvdStats != NULL && strcmp(nvdStats, "0") != 0) {
         char *nvdStatsLog = getenv("NVD_STATS_LOG");
@@ -331,6 +335,10 @@ void logger(const char *filename, const char *function, int line, const char *ms
 
 bool nvdLogDebugEnabled(void) {
     return LOG_DEBUG_ENABLED;
+}
+
+bool nvdSingleBufferForced(void) {
+    return SINGLE_BUFFER_FORCED;
 }
 
 static uint64_t parseEnvU64(const char *name, uint64_t fallback) {

--- a/src/vabackend.h
+++ b/src/vabackend.h
@@ -308,6 +308,7 @@ void nvBackingImageCopyColorMetadata(BackingImage *dst, const BackingImage *src)
 bool checkCudaErrors(CUresult err, const char *file, const char *function, const int line);
 void logger(const char *filename, const char *function, int line, const char *msg, ...);
 bool nvdLogDebugEnabled(void);
+bool nvdSingleBufferForced(void);
 #define CHECK_CUDA_RESULT(err) checkCudaErrors(err, __FILE__, __func__, __LINE__)
 #define CHECK_CUDA_RESULT_RETURN(err, ret) if (checkCudaErrors(err, __FILE__, __func__, __LINE__)) { return ret; }
 #define cudaVideoCodec_NONE ((cudaVideoCodec) -1)


### PR DESCRIPTION
The single-buffer export packs every plane into one dma-buf with the chroma plane at a non-zero byte offset inside a shared block-linear buffer. Chromium's multi-plane import handles that, but per-plane importers (mpv/GStreamer/ffmpeg, which import each layer as a standalone dma-buf) can't detile a tiled plane that starts at a byte offset, so NV12 chroma came out scrambled/stretched under mpv --hwdec=vaapi. Since the direct backend is now the default, this broke hardware decode for every non-Chromium VA-API client.

Allocate each plane in its own dma-buf object at offset 0 instead, while still forcing a single shared block height across planes (via the existing unified layout) so all objects report one DRM modifier -- the invariant Chromium's one-modifier-per-buffer rule needs. Per-plane importers now detile the chroma plane correctly, and Chromium keeps working (num_objects>1 with a common modifier is accepted). The plane's CUDA array is created at the block-aligned height so CUDA tiles it with the advertised block height (same guard as the 144p green-chroma fix). The single-buffer layout stays available behind NVD_SINGLE_BUFFER for comparison.

Verified on RTX 5080: mpv --hwdec=vaapi now renders NV12 correctly at 144p/720p/ 1080p (was corrupt), Chrome still HW-decodes 720p with no GPU-process crash, and H264/VP9/AV1/HEVC10 decode is unchanged.