### PR TITLE
direct: give each plane its own block height in the multi-object export

### DIFF
--- a/src/direct/direct-export-buf.c
+++ b/src/direct/direct-export-buf.c
@@ -409,11 +409,13 @@ static BackingImage *direct_allocateBackingImage_perPlane(NVDriver *drv, NVSurfa
     backingImage->format = nvFormatForSurface(surface);
     const NVFormatInfo *fmtInfo = &formatsInfo[backingImage->format];
 
-    // Reuse the unified layout purely to obtain the shared block height and each plane's
-    // pitch/aligned size; the packed offsets it returns are ignored (each plane is offset 0
-    // in its own buffer).
+    // Reuse the layout purely to obtain each plane's block height and pitch/aligned
+    // size; the packed offsets it returns are ignored (each plane is offset 0 in its
+    // own buffer). Pass unifyBlockHeight=false: each plane is its own dma-buf object
+    // with its own modifier, so it keeps its natural per-plane block height and
+    // matches what the decoder produced (see calculate_unified_image_layout).
     calculate_unified_image_layout(&drv->driverContext, driverImages, surface->width, surface->height,
-                                   fmtInfo->bppc, fmtInfo->numPlanes, fmtInfo->plane);
+                                   fmtInfo->bppc, fmtInfo->numPlanes, fmtInfo->plane, false);
     LOG_DEBUG("Allocating per-plane BackingImage: %p %ux%u", backingImage, surface->width, surface->height);
 
     for (uint32_t i = 0; i < fmtInfo->numPlanes; i++) {
@@ -439,17 +441,18 @@ static BackingImage *direct_allocateBackingImage_perPlane(NVDriver *drv, NVSurfa
         backingImage->fds[i] = drmFd;
         cacheBackingImageFdStat(backingImage, (int) i);
 
-        // Create the array at the block-aligned height (memorySize / pitch) so CUDA tiles
-        // the plane with the same block height the shared modifier advertises; otherwise a
-        // shorter plane (e.g. NV12 chroma below ~170px coded height, whose natural block is
-        // smaller than luma's) is tiled with a smaller block and the importer detiles it
-        // wrong -> green chroma.
-        const uint32_t alignedHeight = driverImages[i].pitch != 0 ?
-            driverImages[i].memorySize / driverImages[i].pitch : driverImages[i].height;
+        // Create the array at the plane's natural height. Each plane is its own object
+        // carrying its own modifier, and calculate_unified_image_layout (called with
+        // unifyBlockHeight=false) already advertised each plane's per-plane block height.
+        // Handing CUDA the natural height makes it derive that same per-plane block, so
+        // the array tiling matches the modifier. (Rounding up to the shared max block --
+        // as the single-buffer path must -- would instead make CUDA pick the larger block
+        // and disagree with the per-plane modifier -> the importer detiles wrong -> green
+        // chroma, e.g. NV12 chroma at a 256x144 coded height.)
         CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC mipmapArrayDesc = {
             .arrayDesc = {
                 .Width = driverImages[i].width,
-                .Height = alignedHeight,
+                .Height = driverImages[i].height,
                 .Depth = 0,
                 .Format = fmtInfo->bppc == 1 ? CU_AD_FORMAT_UNSIGNED_INT8 : CU_AD_FORMAT_UNSIGNED_INT16,
                 .NumChannels = fmtInfo->plane[i].channelCount,
@@ -503,8 +506,10 @@ static BackingImage *direct_allocateBackingImage_single(NVDriver *drv, NVSurface
 
     const NVFormatInfo *fmtInfo = &formatsInfo[backingImage->format];
 
+    // Pass unifyBlockHeight=true: all planes are packed into one shared buffer under a
+    // single DRM modifier, so they must agree on one (largest) block height.
     backingImage->totalSize = calculate_unified_image_layout(&drv->driverContext, driverImages, surface->width, surface->height,
-                                                             fmtInfo->bppc, fmtInfo->numPlanes, fmtInfo->plane);
+                                                             fmtInfo->bppc, fmtInfo->numPlanes, fmtInfo->plane, true);
     LOG_DEBUG("Allocating single BackingImage: %p %ux%u = %u bytes", backingImage, surface->width, surface->height, backingImage->totalSize);
 
     int memFd = -1;

--- a/src/direct/nv-driver.c
+++ b/src/direct/nv-driver.c
@@ -611,25 +611,39 @@ static uint32_t calculate_log2_gobs_per_block_y(const uint32_t height) {
 }
 
 uint32_t calculate_unified_image_layout(const NVDriverContext *context, NVDriverImage images[], const uint32_t width, const uint32_t height,
-                                        const uint32_t bppc, const uint32_t numPlanes, const NVFormatPlane planes[]) {
+                                        const uint32_t bppc, const uint32_t numPlanes, const NVFormatPlane planes[],
+                                        const bool unifyBlockHeight) {
      const uint32_t log2GobsPerBlockX = 0;
      const uint32_t log2GobsPerBlockZ = 0;
 
+     // Each plane's natural block height comes from its own (subsampled) height. How
+     // we use it depends on how the planes get exported:
+     //   - Packed into one shared buffer (single-buffer export): every plane must
+     //     advertise the same DRM modifier, so unify to the largest block height.
+     //     Over-aligning a short plane wastes a little memory but is harmless;
+     //     under-aligning would corrupt it.
+     //   - One dma-buf object per plane (multi-object export): each plane carries its
+     //     own modifier, so keep the exact per-plane value and match what the decoder
+     //     actually produces. A small chroma plane (e.g. a 168x96 video, whose chroma
+     //     is short enough to need a smaller block than luma) is tiled by NVDEC with
+     //     its own block height; forcing it to luma's larger block makes the importer
+     //     detile it wrong -> green chroma.
      uint32_t perPlaneLog2Y[3] = { 0 };
      for (uint32_t i = 0; i < numPlanes; i++) {
          const uint32_t planeHeight = height >> planes[i].ss.y;
          perPlaneLog2Y[i] = calculate_log2_gobs_per_block_y(planeHeight);
      }
 
-     uint32_t log2GobsPerBlockY = perPlaneLog2Y[0];
+     uint32_t unifiedLog2Y = perPlaneLog2Y[0];
      for (uint32_t i = 1; i < numPlanes; i++) {
-         if (perPlaneLog2Y[i] > log2GobsPerBlockY) {
-             log2GobsPerBlockY = perPlaneLog2Y[i];
+         if (perPlaneLog2Y[i] > unifiedLog2Y) {
+             unifiedLog2Y = perPlaneLog2Y[i];
          }
      }
 
      uint32_t offset = 0;
      for (uint32_t i = 0; i < numPlanes; i++) {
+         const uint32_t log2GobsPerBlockY = unifyBlockHeight ? unifiedLog2Y : perPlaneLog2Y[i];
          const uint32_t planeWidth = width >> planes[i].ss.x;
          const uint32_t planeHeight = height >> planes[i].ss.y;
          const uint32_t bytesPerPixel = planes[i].channelCount * bppc;

--- a/src/direct/nv-driver.h
+++ b/src/direct/nv-driver.h
@@ -53,7 +53,8 @@ bool get_device_uuid(const NVDriverContext *context, uint8_t uuid[16]);
 bool alloc_memory(const NVDriverContext *context, uint32_t size, int *fd);
 bool alloc_image(NVDriverContext *context, uint32_t width, uint32_t height, uint8_t channels, uint8_t bytesPerChannel, uint32_t fourcc, NVDriverImage *image);
 uint32_t calculate_unified_image_layout(const NVDriverContext *context, NVDriverImage images[], uint32_t width, uint32_t height,
-                                        uint32_t bppc, uint32_t numPlanes, const NVFormatPlane planes[]);
+                                        uint32_t bppc, uint32_t numPlanes, const NVFormatPlane planes[],
+                                        bool unifyBlockHeight);
 bool alloc_buffer(NVDriverContext *context, uint32_t totalSize, const NVDriverImage images[], int *nvFd, int *nvFd2, int *drmFd);
 
 #endif


### PR DESCRIPTION
Follow-up to #446. This is the `calculate_unified_image_layout` bug you spotted while looking at that 168x96 thumbnail.

Now that multi-plane YUV is exported as one dma-buf object per plane, each plane carries its own DRM modifier. But `calculate_unified_image_layout` was still collapsing all planes to a single (largest) block height — a holdover from the single-buffer layout, where every plane sits in one allocation under one modifier and therefore *has* to agree on one block height. For the multi-object export that's wrong: each plane should keep the per-plane block height the decoder actually produced.

On most videos every plane lands on the same block height so it makes no difference, but on a small enough surface the chroma plane is short enough to want a smaller block than luma (the 168x96 clip is exactly that case). Forcing chroma up to luma's block made the importer detile it with the wrong block height, and the chroma came out green.

The change adds a `unifyBlockHeight` flag to `calculate_unified_image_layout`:

- the single-buffer path passes `true` and keeps the max — all planes share one buffer and one modifier, so they still have to match;
- the multi-object path passes `false` and keeps each plane's own value, matching the decoder.

There's a second half that's easy to miss. In the multi-object path the CUDA array also has to be created at the plane's *natural* height, not the block-aligned height the single-buffer path uses. Otherwise CUDA rounds the chroma array up (e.g. 72 -> 128 rows) and tiles it with the larger block again, which disagrees with the per-plane modifier — and you get green chroma back, just at a different resolution (256x144 instead of 168x96). Handing CUDA the natural height makes it pick the same per-plane block the modifier advertises, so the two agree.

Testing (RTX 5080, comparing mpv's vaapi-egl output against a software decode of the same clip):

- the 168x96 clip that was green now matches software decode;
- H.264 / HEVC 8+10-bit / VP9 / AV1 / MPEG-2 all match at 168x96, 256x144 and 640x360;
- the block-height transition sizes (chroma heights right around the `8 << n` boundaries) and normal resolutions up through 1080p all match;
- decode is unchanged across all of the above;
- the single-buffer path (`NVD_SINGLE_BUFFER=1`) is untouched.
