### PR TITLE
fix: initialize decoder dimensions after config

### DIFF
--- a/src/vabackend.c
+++ b/src/vabackend.c
@@ -1800,8 +1800,6 @@ static VAStatus nvCreateContext(
     }
 
     CUVIDDECODECREATEINFO vdci = {
-        .ulWidth             = vdci.ulMaxWidth  = vdci.ulTargetWidth  = picture_width,
-        .ulHeight            = vdci.ulMaxHeight = vdci.ulTargetHeight = picture_height,
         .CodecType           = cfg->cudaCodec,
         .ulCreationFlags     = cudaVideoCreate_PreferCUVID,
         .ulIntraDecodeOnly   = 0, //TODO (flag & VA_PROGRESSIVE) != 0
@@ -1819,6 +1817,8 @@ static VAStatus nvCreateContext(
         .ulNumDecodeSurfaces = surfaceCount,
         //.vidLock             = drv->vidLock
     };
+    vdci.ulWidth = vdci.ulMaxWidth = vdci.ulTargetWidth = picture_width;
+    vdci.ulHeight = vdci.ulMaxHeight = vdci.ulTargetHeight = picture_height;
 
     CHECK_CUDA_RESULT_RETURN(cu->cuCtxPushCurrent(drv->cudaContext), VA_STATUS_ERROR_OPERATION_FAILED);
 


### PR DESCRIPTION
Mirror the CUVIDDECODECREATEINFO initialization fix from a565237 in `nvCreateContext`. The self-referential initializer can pass invalid dimensions to `cuvidCreateDecoder()`, causing a misleading CUDA out-of-memory error.

Tested:
  - Clean Meson release build with GCC 16.1.1.
  - [example video](https://www.youtube.com/watch?v=njX2bu-_Vw4): AV1 Main, 10-bit HDR, 4K60—120 frames decoded through VA-API as p010.
  - Synthetic H.264 720p—decoded through VA-API as nv12.
  - Chromium 150—remained on VaapiVideoDecoder; NVDEC utilization reached 23–36% on my RTX 3060.